### PR TITLE
fix config setting and add file uploads

### DIFF
--- a/pwpush/__main__.py
+++ b/pwpush/__main__.py
@@ -371,25 +371,25 @@ def make_request(method, path, post_data=None):
 
 
 def json_output() -> Boolean:
-    if cli_options["json"] == True or user_config["cli"]["json"] is True:
+    if cli_options["json"] == True or user_config["cli"]["json"].lower() in ["true", "yes", "on"]:
         return True
     return False
 
 
 def verbose_output() -> Boolean:
-    if cli_options["verbose"] == True or user_config["cli"]["verbose"] is True:
+    if cli_options["verbose"] == True or user_config["cli"]["verbose"].lower() in ["true", "yes", "on"]:
         return True
     return False
 
 
 def debug_output() -> Boolean:
-    if cli_options["debug"] == True or user_config["cli"]["debug"] is True:
+    if cli_options["debug"] == True or user_config["cli"]["debug"].lower() in ["true", "yes", "on"]:
         return True
     return False
 
 
 def pretty_output() -> Boolean:
-    if cli_options["pretty"] == True or user_config["cli"]["pretty"] is True:
+    if cli_options["pretty"] == True or user_config["cli"]["debug"].lower() in ["true", "yes", "on"]:
         return True
     return False
 

--- a/pwpush/commands/config.py
+++ b/pwpush/commands/config.py
@@ -118,7 +118,6 @@ def set(
     Set a configuration value
     """
     key = key.lower()
-    value = value.lower() in ["true", "yes", "on"]
 
     found = False
     for section in user_config.sections():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,13 +22,20 @@ def test_config_show_in_json():
 
 
 def test_config_set():
-    result = runner.invoke(app, ["config", "set", "--key", "json", "--value", "on"])
+    result = runner.invoke(app, ["config", "set", "--key", "json", "--value", "True"])
+    assert "Success" in result.stdout
+    assert result.exit_code == 0
+
+    result = runner.invoke(
+        app, ["config", "set", "--key", "url", "--value", "https://pwpush.test"]
+    )
     assert "Success" in result.stdout
     assert result.exit_code == 0
 
     result = runner.invoke(app, ["--json", "on", "config", "show"])
     config = json.loads(result.stdout.strip())
     assert config["cli"]["json"] == "True"
+    assert config["instance"]["url"] == "https://pwpush.test"
 
 
 def test_config_unset():

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -1,5 +1,4 @@
-import json
-
+import requests
 from typer.testing import CliRunner
 
 from pwpush.__main__ import app
@@ -7,10 +6,49 @@ from pwpush.__main__ import app
 runner = CliRunner()
 
 
-def test_basic_push():
+def build_request_mock(body):
+    class MockResponse(object):
+        def __init__(self, body):
+            self.status_code = 201
+            self.body = body
+
+        def json(self):
+            return body
+
+    def mock(*args, **kwargs):
+        return MockResponse(body)
+
+    return mock
+
+
+def test_basic_push(monkeypatch):
+    monkeypatch.setattr(
+        requests, "post", build_request_mock({"url_token": "super-token"})
+    )
+    monkeypatch.setattr(
+        requests,
+        "get",
+        build_request_mock({"url": "https://pwpush.test/en/p/text-password-url"}),
+    )
+
     result = runner.invoke(app, ["push", "mypassword"])
     assert result.exit_code == 0
-    assert "https://pwpush.com/en/p/" in result.stdout
+    assert "https://pwpush.test/en/p/text-password-url\n" in result.stdout
+
+
+def test_file_push(monkeypatch):
+    monkeypatch.setattr(
+        requests, "post", build_request_mock({"url_token": "super-token"})
+    )
+    monkeypatch.setattr(
+        requests,
+        "get",
+        build_request_mock({"url": "https://pwpush.test/en/f/secret-file-url"}),
+    )
+
+    result = runner.invoke(app, ["push-file", "./README.md"])
+    assert result.exit_code == 0
+    assert "https://pwpush.test/en/f/secret-file-url\n" == result.stdout
 
 
 def test_config_show_in_json():


### PR DESCRIPTION
## Description

The method to update configuration keys forced a type cast into Boolean for any value, including string keys. This PR removes this cast.

I also added a file-upload feature, and edited tests so that they did not depend on pwpush.com to work (or even be logged in).

## Related Issue

https://github.com/pglombardo/pwpush-cli/issues/655

## Type of Change

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

- [x] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/pglombardo/pwpush/blob/master/CODE_OF_CONDUCT.md) document.
- [x] I've read the [`CONTRIBUTING.md`](https://github.com/pglombardo/pwpush/blob/master/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
