### PR TITLE
Add welcome screen for CLI

### DIFF
--- a/pwpush/__main__.py
+++ b/pwpush/__main__.py
@@ -72,8 +72,39 @@ def version_callback(print_version: bool) -> None:
         raise typer.Exit()
 
 
+def show_welcome_screen() -> None:
+    """Display a helpful welcome screen with basic usage information."""
+    console.print()
+    console.print("[bold blue]🔐 Password Pusher CLI[/bold blue]")
+    console.print(f"[dim]Version {version}[/dim]")
+    console.print()
+    console.print("[bold]Quick Start:[/bold]")
+    console.print(
+        "  [cyan]pwpush push[/cyan]                    # Push a password (interactive)"
+    )
+    console.print(
+        "  [cyan]pwpush push --auto[/cyan]             # Auto-generate password"
+    )
+    console.print("  [cyan]pwpush push-file document.pdf[/cyan]  # Upload a file")
+    console.print(
+        "  [cyan]pwpush login[/cyan]                   # Login for advanced features"
+    )
+    console.print()
+    console.print("[bold]Need Help?[/bold]")
+    console.print("  [cyan]pwpush --help[/cyan]                  # Show all commands")
+    console.print(
+        "  [cyan]pwpush push --help[/cyan]             # Help for specific command"
+    )
+    console.print()
+    console.print(
+        "[dim]Securely share passwords, secrets, and files with expiration controls.[/dim]"
+    )
+    console.print()
+
+
 @app.callback(invoke_without_command=True)
 def load_cli_options(
+    ctx: typer.Context,
     json: str = typer.Option(
         False,
         "--json",
@@ -104,6 +135,10 @@ def load_cli_options(
     cli_options["verbose"] = parse_boolean(verbose)
     cli_options["debug"] = parse_boolean(debug)
     cli_options["pretty"] = parse_boolean(pretty)
+
+    # Show welcome screen if no command was provided
+    if ctx.invoked_subcommand is None:
+        show_welcome_screen()
 
 
 @app.command()


### PR DESCRIPTION
- Display helpful welcome screen when running 'python -m pwpush' without commands
- Shows quick start examples and help information
- Includes version number and brief description
- Improves user experience for new users

## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CODE_OF_CONDUCT.md`](https://github.com/pglombardo/pwpush/blob/master/CODE_OF_CONDUCT.md) document.
- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/pglombardo/pwpush/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
