### PR TITLE
feat: display configured server in welcome screen

### DIFF
--- a/pwpush/__main__.py
+++ b/pwpush/__main__.py
@@ -77,6 +77,10 @@ def show_welcome_screen() -> None:
     console.print()
     console.print("[bold blue]🔐 Password Pusher CLI[/bold blue]")
     console.print(f"[dim]Version {version}[/dim]")
+    console.print(f"[dim]Server: {user_config['instance']['url']}[/dim]")
+    console.print(
+        f"[dim]Change server: [cyan]pwpush config set url <new-url>[/cyan][/dim]"
+    )
     console.print()
     console.print("[bold]Quick Start:[/bold]")
     console.print(


### PR DESCRIPTION
## Summary

This PR adds the currently configured Password Pusher server URL to the welcome screen, making it clear which server the CLI will use for API calls.

## Changes

- Display the configured server URL in the welcome screen after the version
- Add a helpful hint showing how to change the server configuration
- Use 'Server' label instead of 'Instance' for better user clarity

## Before
```
🔐 Password Pusher CLI
Version 0.11.0

Quick Start:
  ...
```

## After
```
🔐 Password Pusher CLI
Version 0.11.0
Server: https://pwpush.test
Change server: pwpush config set url <new-url>

Quick Start:
  ...
```

## Benefits

- Users can immediately see which Password Pusher server they're connected to
- Clear guidance on how to change the server configuration
- Better user experience for those using multiple instances (EU, Pro, self-hosted)
- Consistent with CLI best practices of showing current configuration state

## Testing

- ✅ Welcome screen displays correctly with server URL
- ✅ Hint command is properly formatted and actionable
- ✅ Code formatting passes pre-commit hooks