### PR TITLE
feat: add support for push kind parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,12 @@ Get your API token from: https://pwpush.com/en/users/token
 # Push a password with custom settings
 pwpush push --secret "password123" --days 3 --views 10 --deletable
 
+# Push as URL (for sharing links)
+pwpush push --secret "https://example.com" --kind url
+
+# Push as QR code
+pwpush push --secret "QR data content" --kind qr
+
 # Push a file
 pwpush push-file document.pdf --days 7 --views 5
 
@@ -147,6 +153,24 @@ pwpush logout
 ```
 
 ## Advanced Usage
+
+### Push Types
+
+The `--kind` parameter allows you to specify the type of content being pushed:
+
+```bash
+# Text/Password (default)
+pwpush push --secret "mypassword" --kind text
+
+# URL - for sharing links that will be displayed as clickable URLs
+pwpush push --secret "https://example.com" --kind url
+
+# QR Code - for content that will be displayed as a QR code
+pwpush push --secret "QR data content" --kind qr
+
+# File - automatically set when using push-file command
+pwpush push-file document.pdf  # kind is automatically set to "file"
+```
 
 ### JSON Output
 
@@ -211,6 +235,9 @@ pwpush push --secret "db_password_123" --days 1 --views 3 --note "Staging DB - e
 
 # Push API keys securely
 pwpush push --secret "sk_live_..." --days 7 --views 1 --note "Production API Key"
+
+# Share deployment URLs as clickable links
+pwpush push --secret "https://staging.example.com/deploy" --kind url --days 1 --views 5
 ```
 
 ### System Administration

--- a/pwpush/__main__.py
+++ b/pwpush/__main__.py
@@ -219,6 +219,10 @@ def push(
         None,
         help="Optional passphrase to protect the secret (will prompt if not provided)",
     ),
+    kind: str = typer.Option(
+        "text",
+        help="The kind of push to create. Options: text, url, qr. Default: text",
+    ),
 ) -> None:
     """
     Push a new password, secret note or text.
@@ -229,10 +233,23 @@ def push(
         pwpush push --auto                            # Auto-generate password
         pwpush push --secret "data" --deletable       # Allow deletion by viewer
         pwpush push --secret "data" --retrieval-step  # Require click-through
+        pwpush push --secret "https://example.com" --kind url  # Push as URL
+        pwpush push --secret "QR data" --kind qr      # Push as QR code
     """
     path = "/p.json"
 
     data = {"password": {}}
+
+    # Validate kind parameter
+    valid_kinds = ["text", "url", "qr"]
+    if kind not in valid_kinds:
+        rprint(
+            f"[red]Error: Invalid kind '{kind}'. Must be one of: {', '.join(valid_kinds)}[/red]"
+        )
+        raise typer.Exit(1)
+
+    # Set the kind in the request data
+    data["password"]["kind"] = kind
 
     if auto:
         secret = generate_password(50)
@@ -357,6 +374,7 @@ def pushFile(
 
     data = {"file_push": {}}
     data["file_push"]["payload"] = ""
+    data["file_push"]["kind"] = "file"
 
     # Option and user preference processing
     if days:

--- a/pwpush/__main__.py
+++ b/pwpush/__main__.py
@@ -79,7 +79,7 @@ def show_welcome_screen() -> None:
     console.print(f"[dim]Version {version}[/dim]")
     console.print(f"[dim]Server: {user_config['instance']['url']}[/dim]")
     console.print(
-        f"[dim]Change server: [cyan]pwpush config set url <new-url>[/cyan][/dim]"
+        f"[dim]Change server: [cyan]pwpush config set --key url --value <new-url>[/cyan][/dim]"
     )
     console.print()
     console.print("[bold]Quick Start:[/bold]")

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -82,3 +82,23 @@ def test_create_password():
 
     pw2 = generate_password()
     assert len(pw2) == 50
+
+
+def test_push_with_kind_url(mock_make_request):
+    result = runner.invoke(
+        app, ["push", "--secret", "https://example.com", "--kind", "url"]
+    )
+    assert result.exit_code == 0
+    assert "The secret has been pushed to" in result.output
+
+
+def test_push_with_kind_qr(mock_make_request):
+    result = runner.invoke(app, ["push", "--secret", "QR data", "--kind", "qr"])
+    assert result.exit_code == 0
+    assert "The secret has been pushed to" in result.output
+
+
+def test_push_with_invalid_kind():
+    result = runner.invoke(app, ["push", "--secret", "test", "--kind", "invalid"])
+    assert result.exit_code == 1
+    assert "Invalid kind 'invalid'. Must be one of: text, url, qr" in result.output

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -86,19 +86,33 @@ def test_create_password():
 
 def test_push_with_kind_url(mock_make_request):
     result = runner.invoke(
-        app, ["push", "--secret", "https://example.com", "--kind", "url"]
+        app,
+        [
+            "push",
+            "--secret",
+            "https://example.com",
+            "--kind",
+            "url",
+            "--passphrase",
+            "testpass",
+        ],
     )
     assert result.exit_code == 0
     assert "The secret has been pushed to" in result.output
 
 
 def test_push_with_kind_qr(mock_make_request):
-    result = runner.invoke(app, ["push", "--secret", "QR data", "--kind", "qr"])
+    result = runner.invoke(
+        app, ["push", "--secret", "QR data", "--kind", "qr", "--passphrase", "testpass"]
+    )
     assert result.exit_code == 0
     assert "The secret has been pushed to" in result.output
 
 
 def test_push_with_invalid_kind():
-    result = runner.invoke(app, ["push", "--secret", "test", "--kind", "invalid"])
+    result = runner.invoke(
+        app,
+        ["push", "--secret", "test", "--kind", "invalid", "--passphrase", "testpass"],
+    )
     assert result.exit_code == 1
     assert "Invalid kind 'invalid'. Must be one of: text, url, qr" in result.output


### PR DESCRIPTION
## Summary

This PR adds support for the `kind` parameter in the Password Pusher API 1.4, allowing users to specify the type of content being pushed.

## Changes

### New Features
- Added `--kind` parameter to `pwpush push` command with options: `text`, `url`, `qr`
- Default kind is `text` for backward compatibility
- Automatically set `kind='file'` for `push-file` command
- Added input validation for kind parameter with clear error messages

### Documentation Updates
- Updated help text with new examples
- Added comprehensive documentation in README.md
- Added examples for different push types in Advanced Usage section
- Updated developer workflow examples

### Testing
- Added tests for kind parameter validation
- Added tests for valid kind usage
- Added test for invalid kind error handling

## Usage Examples

```bash
# Push as URL (for sharing links)
pwpush push --secret "https://example.com" --kind url

# Push as QR code
pwpush push --secret "QR data content" --kind qr

# Default text push (backward compatible)
pwpush push --secret "mypassword"

# File pushes automatically use kind="file"
pwpush push-file document.pdf
```

## API Integration

The implementation correctly sends the `kind` parameter in the request body according to the [Password Pusher API 1.4 documentation](https://eu.pwpush.com/api/1.4/pushes/create.en.html):

- For regular pushes: `{"password": {"kind": "text|url|qr", ...}}`
- For file pushes: `{"file_push": {"kind": "file", ...}}`

## Backward Compatibility

This change is fully backward compatible:
- Existing commands continue to work exactly as before
- Default `kind="text"` maintains current behavior
- No breaking changes to existing functionality

## Testing

- ✅ Parameter validation works correctly
- ✅ Help text shows the new option
- ✅ Invalid kinds are rejected with clear error messages
- ✅ Valid kinds are accepted and processed
- ✅ All existing tests pass

Closes: Support for Password Pusher API 1.4 kind parameter