### PR TITLE
Improve CLI config and authenticated command UX

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ pwpush expire <url_token>
 
 ```bash
 # View current configuration
-pwpush config show
+pwpush config
 
 # Set default expiration settings
 pwpush config set expire_after_days 7
@@ -164,6 +164,9 @@ pwpush config set expire_after_views 10
 
 # Enable JSON output by default
 pwpush config set json true
+
+# Delete local configuration file (asks for confirmation)
+pwpush config delete
 
 # Logout and clear credentials
 pwpush logout
@@ -284,7 +287,7 @@ pwpush push-file sensitive_document.pdf --days 7 --views 3 --retrieval-step
 **Connection Errors**
 ```bash
 # Check your instance URL
-pwpush config show
+pwpush config
 
 # Test connectivity
 pwpush --debug push --secret "test"
@@ -293,7 +296,7 @@ pwpush --debug push --secret "test"
 **Authentication Issues**
 ```bash
 # Verify your credentials
-pwpush config show
+pwpush config
 
 # Re-login
 pwpush logout
@@ -316,6 +319,7 @@ pwpush --help
 # Get help for specific commands
 pwpush push --help
 pwpush config --help
+pwpush config delete --help
 ```
 
 ## Security Notes

--- a/pwpush/__main__.py
+++ b/pwpush/__main__.py
@@ -245,7 +245,8 @@ def current_api_profile(
 
 def require_api_token(operation: str) -> None:
     """Require a configured API token before authenticated operations."""
-    if user_config["instance"]["token"] == "Not Set":
+    token = user_config["instance"]["token"].strip()
+    if not token or token == "Not Set":
         rprint(
             f"[red]Error: '{operation}' requires an API token. "
             "Run 'pwpush login' or set one with 'pwpush config set token <token>'.[/red]"

--- a/pwpush/__main__.py
+++ b/pwpush/__main__.py
@@ -149,7 +149,10 @@ def show_help_with_config() -> None:
         "  [cyan]pwpush login[/cyan]                                        # Login to instance"
     )
     console.print(
-        "  [cyan]pwpush config show[/cyan]                                  # View configuration"
+        "  [cyan]pwpush config[/cyan]                                       # View configuration"
+    )
+    console.print(
+        "  [cyan]pwpush config delete[/cyan]                                # Delete local config (with confirmation)"
     )
     console.print()
     console.print("[bold]Examples:[/bold]")
@@ -238,6 +241,16 @@ def current_api_profile(
         save_config()
 
     return detected_profile
+
+
+def require_api_token(operation: str) -> None:
+    """Require a configured API token before authenticated operations."""
+    if user_config["instance"]["token"] == "Not Set":
+        rprint(
+            f"[red]Error: '{operation}' requires an API token. "
+            "Run 'pwpush login' or set one with 'pwpush config set token <token>'.[/red]"
+        )
+        raise typer.Exit(1)
 
 
 @app.callback(invoke_without_command=True)
@@ -541,7 +554,7 @@ def pushFile(
     ),
 ) -> None:
     """
-    Push a new file.
+    Push a new file. Requires login with an API token.
 
     Examples:
         pwpush push-file document.pdf                    # Upload a file
@@ -549,6 +562,7 @@ def pushFile(
         pwpush push-file config.json --retrieval-step   # Require click-through
         pwpush push-file backup.zip --days 7 --views 5  # Custom expiration
     """
+    require_api_token("push-file")
     api_profile = current_api_profile()
 
     data: dict[str, dict[str, Any]] = {"file_push": {}}
@@ -627,13 +641,18 @@ def pushFile(
 
 @app.command()
 def expire(
+    ctx: typer.Context,
     url_token: str = typer.Argument(
         "", help="The secret URL token of the push to be expired."
-    )
+    ),
 ) -> None:
     """
     Expire a push.
     """
+    if not url_token:
+        typer.echo(ctx.get_help())
+        raise typer.Exit()
+
     path = push_expire_path(current_api_profile(), url_token)
 
     response = make_request("DELETE", path)
@@ -651,13 +670,20 @@ def expire(
 
 @app.command()
 def audit(
+    ctx: typer.Context,
     url_token: str = typer.Argument(
         "", help="The secret URL token of the push to audit."
-    )
+    ),
 ) -> None:
     """
-    Show the audit log for the given push.
+    Show the audit log for the given push. Requires login with an API token.
     """
+    if not url_token:
+        typer.echo(ctx.get_help())
+        raise typer.Exit()
+
+    require_api_token("audit")
+
     if user_config["instance"]["email"] == "Not Set":
         rprint("You must log into an instance first.")
         raise typer.Exit(1)
@@ -700,8 +726,10 @@ def audit(
 @app.command()
 def list(expired: bool = typer.Option(False, help="Show only expired pushes.")) -> None:
     """
-    List active pushes (if logged in).
+    List active pushes. Requires login with an API token.
     """
+    require_api_token("list")
+
     if user_config["instance"]["email"] == "Not Set":
         rprint("You must log into an instance first.")
         raise typer.Exit(1)
@@ -809,7 +837,11 @@ def pretty_output() -> bool:
     return cli_options["pretty"] or user_config_pretty
 
 
-app.add_typer(config.app, name="config", help="Show & modify CLI configuration.")
+app.add_typer(
+    config.app,
+    name="config",
+    help="Show (default) & modify CLI configuration.",
+)
 
 if __name__ == "__main__":
     app()

--- a/pwpush/commands/config.py
+++ b/pwpush/commands/config.py
@@ -5,13 +5,28 @@ from rich import print as rprint
 from rich.console import Console
 from rich.table import Table
 
-from pwpush.options import json_output, save_config, user_config
+from pwpush.options import (
+    default_config,
+    json_output,
+    save_config,
+    user_config,
+    user_config_file,
+)
 from pwpush.utils import mask_sensitive_value
 
 app = typer.Typer()
 __all__ = ["app", "user_config"]
 
 console = Console()
+
+
+@app.callback(invoke_without_command=True)
+def config_commands(ctx: typer.Context) -> None:
+    """
+    Show configuration when no subcommand is provided.
+    """
+    if ctx.invoked_subcommand is None:
+        show()
 
 
 @app.command()
@@ -227,3 +242,29 @@ def unset(
         save_config()
         rprint("Success")
         raise typer.Exit(code=0)
+
+
+@app.command()
+def delete() -> None:
+    """
+    Delete the local configuration file after confirmation.
+    """
+    typer.confirm(
+        f"Delete config file at '{user_config_file}'? This cannot be undone.",
+        abort=True,
+    )
+
+    if user_config_file.exists():
+        try:
+            user_config_file.unlink()
+            rprint(f"Deleted config file: {user_config_file}")
+        except OSError as exc:
+            rprint(f"[red]Error: Could not delete config file: {exc}[/red]")
+            raise typer.Exit(code=1)
+    else:
+        rprint(f"No config file found at: {user_config_file}")
+
+    # Keep current process in a valid default state even after deletion.
+    user_config.clear()
+    user_config.read_dict(default_config)
+    raise typer.Exit(code=0)

--- a/tests/test_bug_fixes.py
+++ b/tests/test_bug_fixes.py
@@ -12,6 +12,22 @@ from pwpush.utils import parse_boolean
 runner = CliRunner()
 
 
+def configure_api_credentials() -> None:
+    """Configure authenticated command credentials for tests."""
+    from pwpush.commands.config import user_config
+
+    user_config["instance"]["email"] = "user@example.test"
+    user_config["instance"]["token"] = "token-value"
+
+
+def clear_api_token() -> None:
+    """Clear only the API token for missing-token tests."""
+    from pwpush.commands.config import user_config
+
+    user_config["instance"]["email"] = "user@example.test"
+    user_config["instance"]["token"] = "Not Set"
+
+
 @pytest.fixture(autouse=True)
 def default_legacy_profile():
     """Keep existing tests deterministic unless explicitly overridden."""
@@ -264,6 +280,8 @@ def test_push_retrieval_step_none():
 
 def test_push_file_deletable_by_viewer_true():
     """Test that deletable_by_viewer is set to True when --deletable is used in push-file."""
+    configure_api_credentials()
+
     with (
         patch("pwpush.__main__.make_request") as mock_request,
         patch("builtins.open", create=True) as mock_open,
@@ -298,6 +316,8 @@ def test_push_file_deletable_by_viewer_true():
 
 def test_push_file_deletable_by_viewer_false():
     """Test that deletable_by_viewer is set to False when --no-deletable is used in push-file."""
+    configure_api_credentials()
+
     with (
         patch("pwpush.__main__.make_request") as mock_request,
         patch("builtins.open", create=True) as mock_open,
@@ -332,6 +352,8 @@ def test_push_file_deletable_by_viewer_false():
 
 def test_push_file_deletable_by_viewer_none():
     """Test that deletable_by_viewer is not set when no flag is provided in push-file."""
+    configure_api_credentials()
+
     # Reset config values to ensure clean test state
     from pwpush.commands.config import user_config
 
@@ -372,6 +394,8 @@ def test_push_file_deletable_by_viewer_none():
 
 def test_push_file_retrieval_step_true():
     """Test that retrieval_step is set to True when --retrieval-step is used in push-file."""
+    configure_api_credentials()
+
     with (
         patch("pwpush.__main__.make_request") as mock_request,
         patch("builtins.open", create=True) as mock_open,
@@ -406,6 +430,8 @@ def test_push_file_retrieval_step_true():
 
 def test_push_file_retrieval_step_false():
     """Test that retrieval_step is set to False when --no-retrieval-step is used in push-file."""
+    configure_api_credentials()
+
     with (
         patch("pwpush.__main__.make_request") as mock_request,
         patch("builtins.open", create=True) as mock_open,
@@ -442,6 +468,8 @@ def test_push_file_retrieval_step_false():
 
 def test_push_file_retrieval_step_none():
     """Test that retrieval_step is not set when no flag is provided in push-file."""
+    configure_api_credentials()
+
     # Reset config values to ensure clean test state
     from pwpush.commands.config import user_config
 
@@ -496,6 +524,8 @@ def test_pretty_output_fix():
 
 def test_file_not_found_error_handling():
     """Test that file not found errors are handled properly."""
+    configure_api_credentials()
+
     result = runner.invoke(app, ["push-file", "nonexistent-file.txt"])
 
     assert result.exit_code == 1
@@ -602,6 +632,38 @@ def test_list_prefers_v2_endpoint_when_profile_is_v2() -> None:
         assert mock_request.call_args_list[0].args[1] == "/api/v2/pushes/active"
 
 
+def test_list_without_api_token_fails_before_request() -> None:
+    """Test list requires an API token before any API work."""
+    clear_api_token()
+
+    with (
+        patch("pwpush.__main__.current_api_profile") as mock_profile,
+        patch("pwpush.__main__.make_request") as mock_request,
+    ):
+        result = runner.invoke(app, ["list"])
+
+        assert result.exit_code == 1
+        assert "requires an API token" in result.stdout
+        mock_profile.assert_not_called()
+        mock_request.assert_not_called()
+
+
+def test_audit_without_api_token_fails_before_request() -> None:
+    """Test audit requires an API token before any API work."""
+    clear_api_token()
+
+    with (
+        patch("pwpush.__main__.current_api_profile") as mock_profile,
+        patch("pwpush.__main__.make_request") as mock_request,
+    ):
+        result = runner.invoke(app, ["audit", "abc123"])
+
+        assert result.exit_code == 1
+        assert "requires an API token" in result.stdout
+        mock_profile.assert_not_called()
+        mock_request.assert_not_called()
+
+
 def test_push_uses_v2_paths_and_payload_shape() -> None:
     """Test push command uses v2 endpoint and payload envelope."""
     with (
@@ -640,6 +702,8 @@ def test_push_uses_v2_paths_and_payload_shape() -> None:
 
 def test_push_file_uses_v2_paths_payload_and_upload_key() -> None:
     """Test push-file command uses v2 endpoint and multipart key mapping."""
+    configure_api_credentials()
+
     with (
         patch("pwpush.__main__.current_api_profile", return_value="v2"),
         patch("pwpush.__main__.make_request") as mock_request,
@@ -676,6 +740,22 @@ def test_push_file_uses_v2_paths_payload_and_upload_key() -> None:
         )
 
 
+def test_push_file_without_api_token_fails_before_request() -> None:
+    """Test push-file requires an API token before any API work."""
+    clear_api_token()
+
+    with (
+        patch("pwpush.__main__.current_api_profile") as mock_profile,
+        patch("pwpush.__main__.make_request") as mock_request,
+    ):
+        result = runner.invoke(app, ["push-file", "test-file.txt"])
+
+        assert result.exit_code == 1
+        assert "requires an API token" in result.stdout
+        mock_profile.assert_not_called()
+        mock_request.assert_not_called()
+
+
 def test_expire_uses_v2_endpoint() -> None:
     """Test expire command uses v2 route when profile is v2."""
     with (
@@ -691,6 +771,18 @@ def test_expire_uses_v2_endpoint() -> None:
 
         assert result.exit_code == 0
         assert mock_request.call_args_list[0].args[1] == "/api/v2/pushes/abc123"
+
+
+def test_expire_without_token_shows_help() -> None:
+    """Test expire command shows help instead of making a request without a token."""
+    with patch("pwpush.__main__.make_request") as mock_request:
+        result = runner.invoke(app, ["expire"])
+
+        assert result.exit_code == 0
+        assert "Usage:" in result.stdout
+        assert "Expire a push." in result.stdout
+        assert "URL_TOKEN" in result.stdout
+        mock_request.assert_not_called()
 
 
 def test_audit_supports_v2_logs_shape() -> None:
@@ -723,3 +815,24 @@ def test_audit_supports_v2_logs_shape() -> None:
 
         assert result.exit_code == 0
         assert mock_request.call_args_list[0].args[1] == "/api/v2/pushes/abc123/audit"
+
+
+def test_audit_without_token_shows_help() -> None:
+    """Test audit command shows help instead of checking auth without a token."""
+    with patch("pwpush.__main__.make_request") as mock_request:
+        result = runner.invoke(app, ["audit"])
+
+        assert result.exit_code == 0
+        assert "Usage:" in result.stdout
+        assert "Show the audit log for the given push." in result.stdout
+        assert "Requires login with an API token." in result.stdout
+        assert "URL_TOKEN" in result.stdout
+        mock_request.assert_not_called()
+
+
+def test_audit_help_mentions_api_token_requirement() -> None:
+    """Test audit help explains authentication requirements."""
+    result = runner.invoke(app, ["audit", "--help"])
+
+    assert result.exit_code == 0
+    assert "Requires login with an API token." in result.stdout

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,8 +3,16 @@ import json
 from typer.testing import CliRunner
 
 from pwpush.__main__ import app
+from pwpush.options import save_config, user_config
 
 runner = CliRunner()
+
+
+def test_config_defaults_to_show():
+    result = runner.invoke(app, ["config"])
+    assert result.exit_code == 0
+    assert result.stdout.strip()
+    assert "Instance Settings" in result.stdout or '"instance": {' in result.stdout
 
 
 def test_config_show():
@@ -159,3 +167,43 @@ def test_config_set_expiration_settings():
     assert config["expiration"]["expire_after_views"] == "10"
     assert config["expiration"]["retrieval_step"] == "true"
     assert config["expiration"]["deletable_by_viewer"] == "false"
+
+
+def test_config_delete_confirmed(monkeypatch, tmp_path):
+    config_file = tmp_path / "config.ini"
+    monkeypatch.setattr("pwpush.options.user_config_file", config_file)
+    monkeypatch.setattr("pwpush.commands.config.user_config_file", config_file)
+
+    user_config["instance"]["url"] = "https://delete-test.example"
+    save_config()
+    assert config_file.exists()
+
+    result = runner.invoke(app, ["config", "delete"], input="y\n")
+    assert result.exit_code == 0
+    assert "Deleted config file:" in result.stdout
+    assert not config_file.exists()
+
+
+def test_config_delete_aborted(monkeypatch, tmp_path):
+    config_file = tmp_path / "config.ini"
+    monkeypatch.setattr("pwpush.options.user_config_file", config_file)
+    monkeypatch.setattr("pwpush.commands.config.user_config_file", config_file)
+
+    save_config()
+    assert config_file.exists()
+
+    result = runner.invoke(app, ["config", "delete"], input="n\n")
+    assert result.exit_code != 0
+    assert config_file.exists()
+
+
+def test_config_delete_when_file_missing(monkeypatch, tmp_path):
+    config_file = tmp_path / "missing-config.ini"
+    monkeypatch.setattr("pwpush.options.user_config_file", config_file)
+    monkeypatch.setattr("pwpush.commands.config.user_config_file", config_file)
+
+    assert not config_file.exists()
+
+    result = runner.invoke(app, ["config", "delete"], input="y\n")
+    assert result.exit_code == 0
+    assert "No config file found at:" in result.stdout

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -6,6 +6,7 @@ from typer.testing import CliRunner
 
 import pwpush
 from pwpush.__main__ import app, generate_secret, genpass
+from pwpush.commands.config import user_config
 from pwpush.utils import check_secret_conditions
 
 # import the mocks
@@ -53,6 +54,9 @@ def test_basic_push_passphrase(monkeypatch):
 
 
 def test_file_push(monkeypatch):
+    user_config["instance"]["email"] = "user@example.test"
+    user_config["instance"]["token"] = "token-value"
+
     monkeypatch.setattr(
         requests, "post", build_request_mock({"url_token": "super-token"})
     )

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -54,8 +54,8 @@ def test_basic_push_passphrase(monkeypatch):
 
 
 def test_file_push(monkeypatch):
-    user_config["instance"]["email"] = "user@example.test"
-    user_config["instance"]["token"] = "token-value"
+    monkeypatch.setitem(user_config["instance"], "email", "user@example.test")
+    monkeypatch.setitem(user_config["instance"], "token", "token-value")
 
     monkeypatch.setattr(
         requests, "post", build_request_mock({"url_token": "super-token"})


### PR DESCRIPTION
## Summary
- Make `pwpush config` show configuration by default and add confirmed `pwpush config delete`.
- Show command help for `expire` and `audit` when required URL tokens are omitted.
- Fail fast for `audit`, `list`, and `push-file` when no API token is configured.

## Test plan
- `poetry run pytest`
- `poetry run pwpush expire`
- `poetry run pwpush expire -h`
- `poetry run pwpush audit`
- `poetry run pwpush audit -h`