### PR TITLE
Add first-run configuration wizard

### DIFF
--- a/pwpush/__main__.py
+++ b/pwpush/__main__.py
@@ -30,7 +30,8 @@ from pwpush.api.endpoints import (
 )
 from pwpush.commands import config
 from pwpush.commands.config import save_config, user_config
-from pwpush.options import cli_options
+from pwpush.config_wizard import run_config_wizard
+from pwpush.options import cli_options, config_file_exists
 from pwpush.utils import check_secret_conditions, parse_boolean
 
 
@@ -298,6 +299,15 @@ def load_cli_options(
     if ctx.invoked_subcommand is None:
         if help:
             show_help_with_config()
+        elif not config_file_exists():
+            should_run_wizard = typer.confirm(
+                "No configuration file found. Run the setup wizard now?",
+                default=True,
+            )
+            if should_run_wizard:
+                run_config_wizard()
+            else:
+                show_welcome_screen()
         else:
             show_welcome_screen()
 

--- a/pwpush/api/capabilities.py
+++ b/pwpush/api/capabilities.py
@@ -28,7 +28,7 @@ def detect_api_profile(
 
     probe_url = absolute_url(base_url, "/api/v2/version")
     headers: dict[str, str] = {}
-    if email != "Not Set" and token != "Not Set":
+    if token.strip() and token != "Not Set":
         headers = {"Authorization": f"Bearer {token}"}
 
     try:

--- a/pwpush/api/client.py
+++ b/pwpush/api/client.py
@@ -14,16 +14,17 @@ def normalize_base_url(url: str) -> str:
 
 def build_auth_headers(email: str, token: str) -> dict[str, str]:
     """Build the full set of supported auth headers."""
-    valid_email = email != "Not Set"
-    valid_token = token != "Not Set"
-    if not (valid_email and valid_token):
+    valid_email = bool(email.strip()) and email != "Not Set"
+    valid_token = bool(token.strip()) and token != "Not Set"
+    if not valid_token:
         return {}
 
-    return {
-        "X-User-Email": email,
-        "X-User-Token": token,
-        "Authorization": f"Bearer {token}",
-    }
+    headers = {"Authorization": f"Bearer {token}"}
+    if valid_email:
+        headers["X-User-Email"] = email
+        headers["X-User-Token"] = token
+
+    return headers
 
 
 def absolute_url(base_url: str, path: str) -> str:

--- a/pwpush/commands/config.py
+++ b/pwpush/commands/config.py
@@ -5,6 +5,7 @@ from rich import print as rprint
 from rich.console import Console
 from rich.table import Table
 
+from pwpush.config_wizard import run_config_wizard
 from pwpush.options import (
     default_config,
     json_output,
@@ -27,6 +28,24 @@ def config_commands(ctx: typer.Context) -> None:
     """
     if ctx.invoked_subcommand is None:
         show()
+
+
+@app.command()
+def wizard() -> None:
+    """
+    Run the interactive configuration wizard.
+    """
+    run_config_wizard()
+    raise typer.Exit(code=0)
+
+
+@app.command()
+def init() -> None:
+    """
+    Run the interactive configuration wizard.
+    """
+    run_config_wizard()
+    raise typer.Exit(code=0)
 
 
 @app.command()

--- a/pwpush/config_wizard.py
+++ b/pwpush/config_wizard.py
@@ -1,0 +1,227 @@
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+import typer
+from rich.console import Console
+from rich.table import Table
+
+from pwpush.api.client import normalize_base_url
+from pwpush.options import save_config, user_config, user_config_file
+
+NOT_SET = "Not Set"
+
+
+@dataclass(frozen=True)
+class InstanceChoice:
+    """A Password Pusher instance offered by the setup wizard."""
+
+    label: str
+    url: str
+    description: str
+
+
+@dataclass(frozen=True)
+class WizardSettings:
+    """Settings collected by the setup wizard."""
+
+    url: str
+    email: str
+    token: str
+    expire_after_days: str
+    expire_after_views: str
+    retrieval_step: str
+    deletable_by_viewer: str
+    json: str
+    verbose: str
+    pretty: str
+    debug: str
+
+
+HOSTED_INSTANCE_CHOICES: tuple[InstanceChoice, ...] = (
+    InstanceChoice(
+        label="EU hosted",
+        url="https://eu.pwpush.com",
+        description="Pro features; EU Data Residency",
+    ),
+    InstanceChoice(
+        label="US hosted",
+        url="https://us.pwpush.com",
+        description="Pro features; US Data Residency",
+    ),
+    InstanceChoice(
+        label="OSS hosted",
+        url="https://oss.pwpush.com",
+        description="OSS; EU Data Residency; No File Uploads",
+    ),
+)
+
+console = Console()
+
+
+def normalize_instance_url(url: str) -> str:
+    """Normalize a custom instance URL, defaulting to HTTPS for bare domains."""
+    candidate = url.strip()
+    if not candidate:
+        raise ValueError("Instance URL cannot be empty.")
+
+    if not urlparse(candidate).scheme:
+        candidate = f"https://{candidate}"
+
+    parsed = urlparse(candidate)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise ValueError("Instance URL must be a valid HTTP or HTTPS URL.")
+
+    return normalize_base_url(candidate)
+
+
+def choose_instance_url() -> str:
+    """Prompt for the Password Pusher instance URL."""
+    table = Table("Option", "Instance", "Description")
+    for index, choice in enumerate(HOSTED_INSTANCE_CHOICES, start=1):
+        table.add_row(str(index), choice.url, f"{choice.label}: {choice.description}")
+    table.add_row("4", "Custom", "Self-hosted OSS or Pro instance")
+    console.print(table)
+
+    while True:
+        selection = typer.prompt("Choose an instance", default="1").strip()
+        if selection in ("1", "2", "3"):
+            return HOSTED_INSTANCE_CHOICES[int(selection) - 1].url
+        if selection == "4":
+            return prompt_custom_instance_url()
+        console.print("[red]Please choose 1, 2, 3, or 4.[/red]")
+
+
+def prompt_custom_instance_url() -> str:
+    """Prompt for a custom instance URL until a valid value is provided."""
+    while True:
+        url = typer.prompt("Custom instance URL, e.g. https://pwpush.example.com")
+        try:
+            return normalize_instance_url(url)
+        except ValueError as exc:
+            console.print(f"[red]{exc}[/red]")
+
+
+def prompt_optional_int(prompt: str, *, minimum: int, maximum: int) -> str:
+    """Prompt for an optional bounded integer config value."""
+    while True:
+        value = typer.prompt(prompt, default="", show_default=False).strip()
+        if not value:
+            return NOT_SET
+
+        try:
+            parsed = int(value)
+        except ValueError:
+            console.print(
+                f"[red]Enter a number from {minimum} to {maximum}, or leave blank.[/red]"
+            )
+            continue
+
+        if minimum <= parsed <= maximum:
+            return str(parsed)
+
+        console.print(
+            f"[red]Enter a number from {minimum} to {maximum}, or leave blank.[/red]"
+        )
+
+
+def bool_config_value(prompt: str, *, default: bool = False) -> str:
+    """Prompt for a required boolean config value stored as a string."""
+    return str(typer.confirm(prompt, default=default))
+
+
+def collect_wizard_settings() -> WizardSettings:
+    """Collect all setup wizard settings without mutating global config."""
+    url = choose_instance_url()
+
+    email = NOT_SET
+    token = NOT_SET
+    if typer.confirm("Do you want to add an API token?", default=False):
+        token = typer.prompt("API token", hide_input=True)
+
+    expire_after_days = NOT_SET
+    expire_after_views = NOT_SET
+    retrieval_step = NOT_SET
+    deletable_by_viewer = NOT_SET
+    if typer.confirm("Set default expiration preferences?", default=False):
+        expire_after_days = prompt_optional_int(
+            "Default expiration days, 1-90 (blank for server default)",
+            minimum=1,
+            maximum=90,
+        )
+        expire_after_views = prompt_optional_int(
+            "Default expiration views, 1-100 (blank for server default)",
+            minimum=1,
+            maximum=100,
+        )
+        retrieval_step = bool_config_value(
+            "Enable retrieval step by default?",
+            default=False,
+        )
+        deletable_by_viewer = bool_config_value(
+            "Allow viewers to delete pushes by default?",
+            default=False,
+        )
+
+    json = user_config["cli"]["json"]
+    verbose = user_config["cli"]["verbose"]
+    pretty = user_config["cli"]["pretty"]
+    debug = user_config["cli"]["debug"]
+    if typer.confirm("Set CLI output preferences?", default=False):
+        json = bool_config_value("Output JSON by default?", default=False)
+        verbose = bool_config_value("Enable verbose output by default?", default=False)
+        pretty = bool_config_value("Pretty-print JSON by default?", default=False)
+        debug = bool_config_value("Enable debug output by default?", default=False)
+
+    return WizardSettings(
+        url=url,
+        email=email,
+        token=token,
+        expire_after_days=expire_after_days,
+        expire_after_views=expire_after_views,
+        retrieval_step=retrieval_step,
+        deletable_by_viewer=deletable_by_viewer,
+        json=json,
+        verbose=verbose,
+        pretty=pretty,
+        debug=debug,
+    )
+
+
+def apply_wizard_settings(settings: WizardSettings) -> None:
+    """Apply collected wizard settings to the global user config."""
+    previous_url = user_config["instance"]["url"]
+
+    user_config["instance"]["url"] = settings.url
+    user_config["instance"]["email"] = settings.email
+    user_config["instance"]["token"] = settings.token
+
+    if settings.url != previous_url:
+        user_config["instance"]["api_profile"] = NOT_SET
+        user_config["instance"]["api_profile_checked_at"] = "0"
+
+    user_config["expiration"]["expire_after_days"] = settings.expire_after_days
+    user_config["expiration"]["expire_after_views"] = settings.expire_after_views
+    user_config["expiration"]["retrieval_step"] = settings.retrieval_step
+    user_config["expiration"]["deletable_by_viewer"] = settings.deletable_by_viewer
+
+    user_config["cli"]["json"] = settings.json
+    user_config["cli"]["verbose"] = settings.verbose
+    user_config["cli"]["pretty"] = settings.pretty
+    user_config["cli"]["debug"] = settings.debug
+
+
+def run_config_wizard() -> WizardSettings:
+    """Run the interactive configuration wizard and persist the result."""
+    console.print()
+    console.print("[bold blue]Password Pusher CLI Setup[/bold blue]")
+    console.print("This wizard will create your local pwpush configuration.")
+    console.print()
+
+    settings = collect_wizard_settings()
+    apply_wizard_settings(settings)
+    save_config()
+
+    console.print()
+    console.print(f"[green]Configuration saved to {user_config_file}[/green]")
+    console.print()
+    return settings

--- a/pwpush/options.py
+++ b/pwpush/options.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 import configparser
-import os
 from pathlib import Path
 
 import typer
@@ -12,7 +11,7 @@ user_config = configparser.ConfigParser()
 user_config_dir = Path(typer.get_app_dir("pwpush"))
 user_config_file = user_config_dir.joinpath("config.ini")
 
-cli_options = {"json": False, "verbose": False, "debug": False}
+cli_options = {"json": False, "verbose": False, "pretty": False, "debug": False}
 default_config: dict[str, dict[str, Any]] = {"instance": {}}
 default_config["instance"]["url"] = "https://eu.pwpush.com"
 default_config["instance"]["email"] = "Not Set"
@@ -35,54 +34,59 @@ default_config["cli"] = {
 }
 
 
-def load_config():
+def config_file_exists() -> bool:
     """
-    Load existing config or write out a new default one (and use that)
+    Check whether the user configuration file exists.
     """
-    if os.path.exists(user_config_file) is True:
+    return user_config_file.exists()
+
+
+def load_config() -> None:
+    """
+    Load existing config or defaults without creating a config file.
+    """
+    user_config.clear()
+    if config_file_exists():
         user_config.read(user_config_file)
 
-        validate_user_config()
+        if validate_user_config():
+            save_config()
     else:
-        # No config file exists; Write out a new file with default settings
+        # No config file exists; use defaults in memory until explicitly saved.
         user_config.read_dict(default_config)
 
-        # Write out default settings to a new config file
-        if os.path.exists(user_config_dir) is False:
-            Path.mkdir(user_config_dir)
 
-        with open(user_config_file, "x") as file:
-            user_config.write(file)
-
-
-def validate_user_config():
+def validate_user_config() -> bool:
     """
     Validate `user_config` and assure that all default keys are set
-    and available.
+    and available. Returns True when missing values were added.
     """
+    changed = False
+
     if "instance" not in user_config:
         user_config["instance"] = {}
+        changed = True
     if "expiration" not in user_config:
         user_config["expiration"] = {}
+        changed = True
     if "cli" not in user_config:
         user_config["cli"] = {}
+        changed = True
 
-    # Merge the default config into the user config correcting any missing keys
-    # This pattern supports Python >=3.5
-    user_config["instance"] = {**default_config["instance"], **user_config["instance"]}
-    user_config["expiration"] = {
-        **default_config["expiration"],
-        **user_config["expiration"],
-    }
-    user_config["cli"] = {**default_config["cli"], **user_config["cli"]}
-    save_config()
+    for section, defaults in default_config.items():
+        for key, value in defaults.items():
+            if key not in user_config[section]:
+                user_config[section][key] = str(value)
+                changed = True
+
+    return changed
 
 
-def save_config():
+def save_config() -> None:
     """
     Save `user_config` out to file
     """
-    # Write out default settings
+    user_config_file.parent.mkdir(parents=True, exist_ok=True)
     with open(user_config_file, "w") as file:
         user_config.write(file)
 

--- a/tests/test_api_capabilities.py
+++ b/tests/test_api_capabilities.py
@@ -61,3 +61,22 @@ def test_detect_api_profile_caches_results_per_base_url() -> None:
         assert first == API_PROFILE_V2
         assert second == API_PROFILE_V2
         assert mock_get.call_count == 1
+
+
+def test_detect_api_profile_uses_bearer_token_without_email() -> None:
+    clear_profile_cache()
+    with patch("pwpush.api.capabilities.requests.get") as mock_get:
+        response = MagicMock()
+        response.status_code = 200
+        mock_get.return_value = response
+
+        profile = detect_api_profile(
+            base_url="https://example.test",
+            email="Not Set",
+            token="test-token",
+        )
+
+        assert profile == API_PROFILE_V2
+        assert mock_get.call_args.kwargs["headers"] == {
+            "Authorization": "Bearer test-token"
+        }

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,0 +1,15 @@
+from pwpush.api.client import build_auth_headers
+
+
+def test_build_auth_headers_uses_bearer_token_without_email() -> None:
+    assert build_auth_headers("Not Set", "test-token") == {
+        "Authorization": "Bearer test-token"
+    }
+
+
+def test_build_auth_headers_includes_legacy_headers_when_email_is_set() -> None:
+    assert build_auth_headers("user@example.test", "test-token") == {
+        "Authorization": "Bearer test-token",
+        "X-User-Email": "user@example.test",
+        "X-User-Token": "test-token",
+    }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,9 +3,53 @@ import json
 from typer.testing import CliRunner
 
 from pwpush.__main__ import app
-from pwpush.options import save_config, user_config
+from pwpush.options import default_config, load_config, save_config, user_config
 
 runner = CliRunner()
+
+
+def reset_config_file(monkeypatch, config_file):
+    monkeypatch.setattr("pwpush.options.user_config_file", config_file)
+    monkeypatch.setattr("pwpush.commands.config.user_config_file", config_file)
+    monkeypatch.setattr("pwpush.config_wizard.user_config_file", config_file)
+    user_config.clear()
+    user_config.read_dict(default_config)
+
+
+def test_load_config_uses_defaults_without_writing_file(monkeypatch, tmp_path):
+    config_file = tmp_path / "config.ini"
+    reset_config_file(monkeypatch, config_file)
+    user_config.clear()
+
+    load_config()
+
+    assert user_config["instance"]["url"] == "https://eu.pwpush.com"
+    assert user_config["cli"]["pretty"] == "False"
+    assert not config_file.exists()
+
+
+def test_save_config_creates_parent_directory(monkeypatch, tmp_path):
+    config_file = tmp_path / "nested" / "config.ini"
+    reset_config_file(monkeypatch, config_file)
+
+    save_config()
+
+    assert config_file.exists()
+
+
+def test_load_config_validates_partial_existing_config(monkeypatch, tmp_path):
+    config_file = tmp_path / "config.ini"
+    reset_config_file(monkeypatch, config_file)
+    config_file.write_text("[instance]\nurl = https://partial.example\n")
+    user_config.clear()
+
+    load_config()
+
+    assert user_config["instance"]["url"] == "https://partial.example"
+    assert user_config["instance"]["token"] == "Not Set"
+    assert user_config["expiration"]["expire_after_days"] == "Not Set"
+    assert user_config["cli"]["debug"] == "False"
+    assert config_file.exists()
 
 
 def test_config_defaults_to_show():

--- a/tests/test_config_wizard.py
+++ b/tests/test_config_wizard.py
@@ -1,0 +1,181 @@
+import json
+
+from typer.testing import CliRunner
+
+from pwpush.__main__ import app
+from pwpush.config_wizard import (
+    WizardSettings,
+    apply_wizard_settings,
+    normalize_instance_url,
+)
+from pwpush.options import default_config, user_config
+
+runner = CliRunner()
+
+
+def reset_config_file(monkeypatch, config_file):
+    monkeypatch.setattr("pwpush.options.user_config_file", config_file)
+    monkeypatch.setattr("pwpush.commands.config.user_config_file", config_file)
+    monkeypatch.setattr("pwpush.config_wizard.user_config_file", config_file)
+    user_config.clear()
+    user_config.read_dict(default_config)
+
+
+def test_normalize_instance_url_defaults_bare_domains_to_https():
+    assert normalize_instance_url("pwpush.example.com/") == "https://pwpush.example.com"
+
+
+def test_apply_wizard_settings_resets_cached_profile_on_instance_change():
+    user_config["instance"]["url"] = "https://old.example"
+    user_config["instance"]["api_profile"] = "v2"
+    user_config["instance"]["api_profile_checked_at"] = "123"
+
+    settings = WizardSettings(
+        url="https://new.example",
+        email="Not Set",
+        token="Not Set",
+        expire_after_days="7",
+        expire_after_views="10",
+        retrieval_step="True",
+        deletable_by_viewer="False",
+        json="False",
+        verbose="True",
+        pretty="False",
+        debug="False",
+    )
+
+    apply_wizard_settings(settings)
+
+    assert user_config["instance"]["url"] == "https://new.example"
+    assert user_config["instance"]["api_profile"] == "Not Set"
+    assert user_config["instance"]["api_profile_checked_at"] == "0"
+    assert user_config["expiration"]["expire_after_days"] == "7"
+    assert user_config["expiration"]["expire_after_views"] == "10"
+    assert user_config["expiration"]["retrieval_step"] == "True"
+    assert user_config["expiration"]["deletable_by_viewer"] == "False"
+    assert user_config["cli"]["verbose"] == "True"
+
+
+def test_config_wizard_saves_us_instance_and_skipped_preferences(monkeypatch, tmp_path):
+    config_file = tmp_path / "config.ini"
+    reset_config_file(monkeypatch, config_file)
+
+    result = runner.invoke(app, ["config", "wizard"], input="2\nn\nn\nn\n")
+
+    assert result.exit_code == 0
+    assert config_file.exists()
+    assert user_config["instance"]["url"] == "https://us.pwpush.com"
+    assert user_config["instance"]["email"] == "Not Set"
+    assert user_config["instance"]["token"] == "Not Set"
+    assert user_config["expiration"]["expire_after_days"] == "Not Set"
+    assert user_config["expiration"]["expire_after_views"] == "Not Set"
+    assert user_config["expiration"]["retrieval_step"] == "Not Set"
+    assert user_config["expiration"]["deletable_by_viewer"] == "Not Set"
+
+
+def test_config_wizard_saves_oss_instance(monkeypatch, tmp_path):
+    config_file = tmp_path / "config.ini"
+    reset_config_file(monkeypatch, config_file)
+
+    result = runner.invoke(app, ["config", "wizard"], input="3\nn\nn\nn\n")
+
+    assert result.exit_code == 0
+    assert user_config["instance"]["url"] == "https://oss.pwpush.com"
+
+
+def test_config_wizard_saves_custom_instance_and_preferences(monkeypatch, tmp_path):
+    config_file = tmp_path / "config.ini"
+    reset_config_file(monkeypatch, config_file)
+
+    result = runner.invoke(
+        app,
+        ["config", "wizard"],
+        input=(
+            "4\n"
+            "pwpush.example.com/\n"
+            "y\n"
+            "token-value\n"
+            "y\n"
+            "7\n"
+            "10\n"
+            "y\n"
+            "n\n"
+            "y\n"
+            "y\n"
+            "n\n"
+            "y\n"
+            "n\n"
+        ),
+    )
+
+    assert result.exit_code == 0
+    assert user_config["instance"]["url"] == "https://pwpush.example.com"
+    assert user_config["instance"]["email"] == "Not Set"
+    assert user_config["instance"]["token"] == "token-value"
+    assert user_config["expiration"]["expire_after_days"] == "7"
+    assert user_config["expiration"]["expire_after_views"] == "10"
+    assert user_config["expiration"]["retrieval_step"] == "True"
+    assert user_config["expiration"]["deletable_by_viewer"] == "False"
+    assert user_config["cli"]["json"] == "True"
+    assert user_config["cli"]["verbose"] == "False"
+    assert user_config["cli"]["pretty"] == "True"
+    assert user_config["cli"]["debug"] == "False"
+
+
+def test_first_run_decline_shows_welcome_without_creating_config(monkeypatch, tmp_path):
+    config_file = tmp_path / "config.ini"
+    reset_config_file(monkeypatch, config_file)
+
+    result = runner.invoke(app, [], input="n\n")
+
+    assert result.exit_code == 0
+    assert "Password Pusher CLI" in result.stdout
+    assert not config_file.exists()
+
+
+def test_first_run_accept_runs_wizard_and_writes_config(monkeypatch, tmp_path):
+    config_file = tmp_path / "config.ini"
+    reset_config_file(monkeypatch, config_file)
+
+    result = runner.invoke(app, [], input="y\n3\nn\nn\nn\n")
+
+    assert result.exit_code == 0
+    assert "Password Pusher CLI Setup" in result.stdout
+    assert config_file.exists()
+    assert user_config["instance"]["url"] == "https://oss.pwpush.com"
+
+
+def test_no_arg_with_existing_config_does_not_prompt(monkeypatch, tmp_path):
+    config_file = tmp_path / "config.ini"
+    reset_config_file(monkeypatch, config_file)
+    config_file.write_text("[instance]\nurl = https://existing.example\n")
+
+    result = runner.invoke(app, [])
+
+    assert result.exit_code == 0
+    assert "Run the setup wizard" not in result.stdout
+    assert "Password Pusher CLI" in result.stdout
+
+
+def test_help_does_not_prompt_or_create_config(monkeypatch, tmp_path):
+    config_file = tmp_path / "config.ini"
+    reset_config_file(monkeypatch, config_file)
+
+    result = runner.invoke(app, ["--help"])
+
+    assert result.exit_code == 0
+    assert "Run the setup wizard" not in result.stdout
+    assert "Available Commands" in result.stdout
+    assert not config_file.exists()
+
+
+def test_config_show_works_without_existing_file(monkeypatch, tmp_path):
+    config_file = tmp_path / "config.ini"
+    reset_config_file(monkeypatch, config_file)
+
+    result = runner.invoke(app, ["--json", "on", "config", "show"])
+    config = json.loads(result.stdout.strip())
+
+    assert result.exit_code == 0
+    assert config["instance"]["url"] == "https://eu.pwpush.com"
+    assert not config_file.exists()


### PR DESCRIPTION
## Summary
- Add a first-run configuration wizard with hosted and custom instance selection.
- Avoid creating config files at import time while preserving in-memory defaults.
- Prefer API v2 Bearer token auth while preserving legacy headers when email is configured.

## Test plan
- poetry run pytest
- poetry run black --check pwpush/config_wizard.py pwpush/api/client.py pwpush/api/capabilities.py tests/test_config_wizard.py tests/test_api_capabilities.py tests/test_api_client.py