### PR TITLE
Fix push command help formatting and improve interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,19 @@ pip install pwpush
 
 ## Quick Start
 
-### 1. Basic Usage (Anonymous)
+### 1. Guided Setup
+
+Run the setup wizard to choose your Password Pusher instance, optionally add an
+API token, and set default expiration/output preferences:
+
+```bash
+pwpush config wizard
+```
+
+On first run, `pwpush` will also offer to launch this wizard automatically if no
+local configuration file exists.
+
+### 2. Basic Usage
 
 ```bash
 # Push a password (interactive mode)
@@ -82,22 +94,21 @@ pwpush push --auto
 pwpush push --secret "mypassword" --days 7 --views 5
 ```
 
-### 2. Configure Your Instance
+### 3. Configure Your Instance
 
 The CLI works with multiple Password Pusher instances:
 
 ```bash
-# Use the EU instance
+# Recommended: guided setup/update
+pwpush config wizard
+
+# Advanced: direct configuration edits
 pwpush config set url https://eu.pwpush.com
-
-# Use the US instance
 pwpush config set url https://us.pwpush.com
-
-# Use your own self-hosted instance
 pwpush config set url https://pwpush.yourdomain.com
 ```
 
-### 3. Authentication (Optional)
+### 4. Authentication (Optional)
 
 For advanced features like listing pushes and audit logs, authenticate with your account:
 
@@ -155,10 +166,13 @@ pwpush expire <url_token>
 ### Configuration
 
 ```bash
+# Guided setup/update (recommended)
+pwpush config wizard
+
 # View current configuration
 pwpush config
 
-# Set default expiration settings
+# Advanced: set default expiration settings directly
 pwpush config set expire_after_days 7
 pwpush config set expire_after_views 10
 

--- a/pwpush/__main__.py
+++ b/pwpush/__main__.py
@@ -48,7 +48,7 @@ app = typer.Typer(
     name="pwpush",
     help="Command Line Interface to Password Pusher - securely share passwords, secrets, and files with expiration controls.",
     add_completion=False,
-    rich_markup_mode="markdown",
+    rich_markup_mode="rich",
     pretty_exceptions_show_locals=False,
     context_settings=dict(help_option_names=["-h", "--help"]),
 )
@@ -100,10 +100,11 @@ def show_welcome_screen() -> None:
     console.print(f"[dim]Version {version}[/dim]")
     console.print(f"[dim]Server: {user_config['instance']['url']}[/dim]")
     console.print(
-        f"[dim]Change server: [cyan]pwpush config set url <new-url>[/cyan][/dim]"
+        "[dim]Setup or change defaults: " "[cyan]pwpush config wizard[/cyan][/dim]"
     )
     console.print()
     console.print("[bold]Quick Start:[/bold]")
+    console.print("  [cyan]pwpush config wizard[/cyan]           # Guided setup")
     console.print(
         "  [cyan]pwpush push[/cyan]                    # Push a password (interactive)"
     )
@@ -142,30 +143,33 @@ def show_help_with_config() -> None:
         "Command Line Interface to Password Pusher - securely share passwords, secrets, and files with expiration controls."
     )
     console.print()
-    console.print("[bold]Configuration:[/bold]")
+    console.print("[bold]Getting Started:[/bold]")
     console.print(
-        "  [cyan]pwpush config set url <instance-url>[/cyan]  # Set Password Pusher instance"
+        "  [cyan]pwpush config wizard[/cyan]           # Guided setup for instance, token, defaults"
     )
     console.print(
-        "  [cyan]pwpush login[/cyan]                                        # Login to instance"
+        "  [cyan]pwpush push[/cyan]                    # Push a password or secret interactively"
     )
     console.print(
-        "  [cyan]pwpush config[/cyan]                                       # View configuration"
-    )
-    console.print(
-        "  [cyan]pwpush config delete[/cyan]                                # Delete local config (with confirmation)"
-    )
-    console.print()
-    console.print("[bold]Examples:[/bold]")
-    console.print(
-        "  [cyan]pwpush push[/cyan]                    # Push a password (interactive)"
-    )
-    console.print(
-        "  [cyan]pwpush push --auto[/cyan]             # Auto-generate password"
+        "  [cyan]pwpush push --auto[/cyan]             # Generate and push a secure password"
     )
     console.print("  [cyan]pwpush push-file document.pdf[/cyan]  # Upload a file")
+    console.print()
+    console.print("[bold]Configuration:[/bold]")
     console.print(
-        "  [cyan]pwpush login[/cyan]                   # Login for advanced features"
+        "  [cyan]pwpush config wizard[/cyan]                  # Recommended: guided setup/update"
+    )
+    console.print(
+        "  [cyan]pwpush config[/cyan]                         # View current configuration"
+    )
+    console.print(
+        "  [cyan]pwpush login[/cyan]                          # Add account credentials/API token"
+    )
+    console.print(
+        "  [cyan]pwpush config set <key> <value>[/cyan]        # Advanced: direct config edit"
+    )
+    console.print(
+        "  [cyan]pwpush config delete[/cyan]                  # Delete local config (with confirmation)"
     )
     console.print()
     console.print("[bold]Available Commands:[/bold]")
@@ -180,7 +184,9 @@ def show_help_with_config() -> None:
     console.print("  [cyan]expire[/cyan]      Expire a push")
     console.print("  [cyan]audit[/cyan]       Show the audit log for the given push")
     console.print("  [cyan]list[/cyan]        List active pushes (if logged in)")
-    console.print("  [cyan]config[/cyan]      Show & modify CLI configuration")
+    console.print(
+        "  [cyan]config[/cyan]      Setup, show, and modify CLI configuration"
+    )
     console.print()
     console.print("[bold]Global Options:[/bold]")
     console.print("  [cyan]--json, -j[/cyan]     Output results in JSON format")
@@ -191,6 +197,9 @@ def show_help_with_config() -> None:
     console.print()
     console.print("[bold]Need More Help?[/bold]")
     console.print("  [cyan]pwpush <command> --help[/cyan]  # Help for specific command")
+    console.print(
+        "  [cyan]pwpush config --help[/cyan]     # Configuration wizard and direct edits"
+    )
     console.print()
 
 
@@ -382,7 +391,23 @@ def logout() -> None:
         rprint("Log out successful.")
 
 
-@app.command()
+HELP_TEXT = """Push a new password, secret note or text.
+
+[dim]Examples:[/]
+[code]
+pwpush push                                      # Interactive mode
+pwpush push --secret "mypassword"                # Direct secret
+pwpush push --auto                               # Auto-generate password
+pwpush push --secret "data" --deletable          # Allow deletion by viewer
+pwpush push --secret "data" --retrieval-step     # Require click-through
+pwpush push --secret "https://..." --kind url    # Push as URL
+pwpush push --secret "QR data" --kind qr         # Push as QR code
+pwpush push --secret "data" --passphrase "pass"  # With passphrase
+pwpush push --secret "data" --prompt-passphrase  # Prompt for passphrase
+[/code]"""
+
+
+@app.command(help=HELP_TEXT)
 def push(
     ctx: typer.Context,
     days: int | None = typer.Option(None, help="Expire after this many days."),
@@ -402,8 +427,6 @@ def push(
     secret: str | None = typer.Option(
         None,
         help="The secret text/password to push (will prompt if not provided)",
-        hide_input=True,
-        confirmation_prompt=True,
     ),
     passphrase: str | None = typer.Option(
         None,
@@ -419,20 +442,6 @@ def push(
         help="The kind of push to create. Options: text, url, qr. Default: text",
     ),
 ) -> None:
-    """
-    Push a new password, secret note or text.
-
-    Examples:
-        pwpush push                                    # Interactive mode
-        pwpush push --secret "mypassword"             # Direct secret
-        pwpush push --auto                            # Auto-generate password
-        pwpush push --secret "data" --deletable       # Allow deletion by viewer
-        pwpush push --secret "data" --retrieval-step  # Require click-through
-        pwpush push --secret "https://example.com" --kind url  # Push as URL
-        pwpush push --secret "QR data" --kind qr      # Push as QR code
-        pwpush push --secret "data" --passphrase "pass"  # With passphrase
-        pwpush push --secret "data" --prompt-passphrase  # Prompt for passphrase
-    """
     data: dict[str, dict[str, Any]] = {"password": {}}
     api_profile = current_api_profile()
 
@@ -451,10 +460,40 @@ def push(
         secret = generate_secret(50)
         passphrase = genpass(2)
 
-    if not secret:
-        secret = typer.prompt("Enter secret", hide_input=True, confirmation_prompt=True)
+    # If secret not provided via --secret, prompt for it interactively
+    if secret is None and not auto:
+        secret = getpass.getpass("Enter secret: ")
 
-    # Handle passphrase logic
+    # Interactive mode: ask if user wants to add a passphrase
+    # This happens when secret was prompted (not via --secret)
+    # and --passphrase wasn't provided, and --prompt-passphrase wasn't used
+    secret_from_cli = ctx.params.get("secret") is not None
+    if (
+        not secret_from_cli
+        and secret is not None
+        and passphrase is None
+        and not prompt_passphrase
+        and not auto
+    ):
+        add_passphrase = typer.confirm(
+            "Would you like to add a passphrase to protect this secret?",
+            default=False,
+        )
+        if add_passphrase:
+            while True:
+                first = getpass.getpass("Enter passphrase: ")
+                if not first:
+                    rprint(
+                        "[yellow]Passphrase cannot be empty. Try again or press Ctrl+C to cancel.[/yellow]"
+                    )
+                    continue
+                second = getpass.getpass("Confirm passphrase: ")
+                if first == second:
+                    passphrase = first
+                    break
+                rprint("[red]Passphrases do not match. Please try again.[/red]")
+
+    # Handle --prompt-passphrase flag (explicit passphrase prompting)
     if prompt_passphrase:
         # User provided --prompt-passphrase flag, prompt for it
         first = None
@@ -851,7 +890,7 @@ def pretty_output() -> bool:
 app.add_typer(
     config.app,
     name="config",
-    help="Show (default) & modify CLI configuration.",
+    help="Setup, show, and modify CLI configuration.",
 )
 
 if __name__ == "__main__":

--- a/pwpush/commands/config.py
+++ b/pwpush/commands/config.py
@@ -15,7 +15,10 @@ from pwpush.options import (
 )
 from pwpush.utils import mask_sensitive_value
 
-app = typer.Typer()
+app = typer.Typer(
+    rich_markup_mode="markdown",
+    context_settings=dict(help_option_names=["-h", "--help"]),
+)
 __all__ = ["app", "user_config"]
 
 console = Console()
@@ -25,6 +28,8 @@ console = Console()
 def config_commands(ctx: typer.Context) -> None:
     """
     Show configuration when no subcommand is provided.
+
+    Run `pwpush config wizard` for guided setup.
     """
     if ctx.invoked_subcommand is None:
         show()
@@ -33,7 +38,10 @@ def config_commands(ctx: typer.Context) -> None:
 @app.command()
 def wizard() -> None:
     """
-    Run the interactive configuration wizard.
+    Run the guided setup wizard.
+
+    This is the recommended way to choose your Password Pusher instance, add an
+    API token, and set default expiration/output preferences.
     """
     run_config_wizard()
     raise typer.Exit(code=0)
@@ -42,7 +50,7 @@ def wizard() -> None:
 @app.command()
 def init() -> None:
     """
-    Run the interactive configuration wizard.
+    Alias for `pwpush config wizard`.
     """
     run_config_wizard()
     raise typer.Exit(code=0)
@@ -58,7 +66,7 @@ def show(
     ),
 ) -> None:
     """
-    Show current configuration values
+    Show current configuration values.
     """
     # Check both the local flag and the global CLI options
     from pwpush.options import cli_options
@@ -167,7 +175,8 @@ def show(
         console.print(table)
 
         rprint()
-        rprint("To change the above the values see: 'pwpush config set --help'")
+        rprint("To update these values, run 'pwpush config wizard'.")
+        rprint("For direct edits, see 'pwpush config set --help'.")
         rprint()
         rprint("User config is saved in '%s/config.ini'" % typer.get_app_dir("pwpush"))
         rprint()
@@ -188,17 +197,10 @@ def set(
     ),
 ) -> None:
     """
-    Set a configuration value
+    Directly set a configuration value.
 
-    Examples:
-        # Using positional arguments (recommended)
-        pwpush config set url https://pwpush.com
-        pwpush config set email user@example.com
-        pwpush config set expire_after_days 7
-
-        # Using flags (alternative)
-        pwpush config set --key url --value https://pwpush.com
-        pwpush config set --key email --value user@example.com
+    Most users should run `pwpush config wizard` for guided setup. Use this
+    command when you know the exact config key to change.
     """
     # Determine which method was used and get the values
     if key_flag is not None or value_flag is not None:
@@ -245,7 +247,7 @@ def unset(
     key: str = typer.Option(..., help="The key to unset."),
 ) -> None:
     """
-    Unset a configuration value
+    Directly unset a configuration value.
     """
     found = False
     for section in user_config.sections():

--- a/tests/test_config_wizard.py
+++ b/tests/test_config_wizard.py
@@ -165,7 +165,22 @@ def test_help_does_not_prompt_or_create_config(monkeypatch, tmp_path):
 
     assert result.exit_code == 0
     assert "Run the setup wizard" not in result.stdout
+    assert "pwpush config wizard" in result.stdout
+    assert "Recommended: guided setup/update" in result.stdout
+    assert "Advanced: direct config edit" in result.stdout
     assert "Available Commands" in result.stdout
+    assert not config_file.exists()
+
+
+def test_config_help_promotes_wizard_before_direct_edits(monkeypatch, tmp_path):
+    config_file = tmp_path / "config.ini"
+    reset_config_file(monkeypatch, config_file)
+
+    result = runner.invoke(app, ["config", "--help"])
+
+    assert result.exit_code == 0
+    assert "Run the guided setup wizard" in result.stdout
+    assert "Directly set a configuration value" in result.stdout
     assert not config_file.exists()
 
 


### PR DESCRIPTION
## Summary

This PR fixes the improperly formatted examples in `pwpush push -h` and improves the interactive mode user experience.

## Changes

### 1. Fix Help Text Formatting
- Changed `rich_markup_mode` from `"markdown"` to `"rich"` to enable proper markup processing
- Moved examples from docstring to a `HELP_TEXT` constant using `[code]` tags
- Examples now display properly on separate lines instead of being collapsed into one wrapped line

### 2. Improve Interactive Mode
- Removed `confirmation_prompt=True` from `--secret` option to eliminate double-prompting
- Added an interactive prompt asking users if they want to add a passphrase when in interactive mode
- If yes, prompts for passphrase with confirmation (must match)
- When using `--secret` flag, skips the passphrase prompt (user can still use `--passphrase` or `--prompt-passphrase`)

### 3. UX Improvements
- Updated welcome screen and help text to promote the config wizard
- Added clearer quick-start examples

## Before
```
Examples:     pwpush push                                    # Interactive mode     pwpush push --secret "mypassword"             # Direct secret ...
```

## After
```
Examples:

pwpush push                                      # Interactive mode
pwpush push --secret "mypassword"                # Direct secret
pwpush push --auto                               # Auto-generate password
...
```

## Testing
- Verified `poetry run pwpush push -h` displays correctly
- Tested interactive mode with and without passphrase
- Tested `--secret` flag mode (no passphrase prompt)
- Tested passphrase confirmation with mismatch handling