### PR TITLE
Add Pro notification features: --notify and --notify-locale options

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,26 @@ pwpush logout
 
 ## Advanced Usage
 
+### Pro Features (pwpush.com)
+
+Password Pusher Pro supports email notifications when pushes are accessed. This feature requires authentication and is automatically detected from your instance's capabilities.
+
+```bash
+# Notify specific emails when the push is accessed (requires login)
+pwpush push --secret "password123" --notify "admin@company.com,security@company.com"
+
+# Set locale for notification emails
+pwpush push --secret "password123" --notify "admin@company.com" --notify-locale "en"
+
+# File push with notifications
+pwpush push-file document.pdf --notify "admin@company.com"
+```
+
+**Requirements:**
+- Authentication required (API token must be set via `pwpush login`)
+- API version 2.1 or higher
+- The `email_auto_dispatch` feature enabled on your instance
+
 ### Push Types
 
 The `--kind` parameter allows you to specify the type of content being pushed:
@@ -258,6 +278,15 @@ done
 |-----|-------------|--------------|
 | `json` | Output in JSON format | true/false |
 | `verbose` | Enable verbose output | true/false |
+
+### Pro Settings
+
+| Key | Description | Valid Values |
+|-----|-------------|--------------|
+| `notify` | Default email addresses for notifications | Comma-separated emails |
+| `notify_locale` | Default locale for notification emails | `en`, `es`, `fr`, `de`, etc. |
+
+**Note:** These settings require a Password Pusher Pro instance with email notifications enabled.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -283,10 +283,10 @@ done
 
 | Key | Description | Valid Values |
 |-----|-------------|--------------|
-| `notify` | Default email addresses for notifications | Comma-separated emails |
-| `notify_locale` | Default locale for notification emails | `en`, `es`, `fr`, `de`, etc. |
+| `notify` | Notification email addresses stored in configuration | Comma-separated emails |
+| `notify_locale` | Notification email locale stored in configuration | `en`, `es`, `fr`, `de`, etc. |
 
-**Note:** These settings require a Password Pusher Pro instance with email notifications enabled.
+**Note:** These settings require a Password Pusher Pro instance with email notifications enabled. They are stored in your config file but are not currently applied automatically as defaults by the `push` or `push-file` commands.
 
 ## Examples
 

--- a/pwpush/__main__.py
+++ b/pwpush/__main__.py
@@ -456,7 +456,7 @@ def push(
     notify_locale: str | None = typer.Option(
         None,
         "--notify-locale",
-        help="Locale for notification emails (e.g., 'en', 'es', 'fr', 'de'). Default: 'en'. Requires --notify to be set.",
+        help="Locale for notification emails (e.g., 'en', 'es', 'fr', 'de'). Only used when --notify is set.",
     ),
 ) -> None:
     data: dict[str, dict[str, Any]] = {"password": {}}
@@ -668,7 +668,7 @@ def pushFile(
     notify_locale: str | None = typer.Option(
         None,
         "--notify-locale",
-        help="Locale for notification emails (e.g., 'en', 'es', 'fr', 'de'). Default: 'en'. Requires --notify to be set.",
+        help="Locale for notification emails (e.g., 'en', 'es', 'fr', 'de'). Only used when --notify is set.",
     ),
     payload: str = typer.Argument(
         "",

--- a/pwpush/__main__.py
+++ b/pwpush/__main__.py
@@ -16,7 +16,11 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 from rich.table import Table
 
 from pwpush import version
-from pwpush.api.capabilities import detect_api_profile
+from pwpush.api.capabilities import (
+    detect_api_capabilities,
+    detect_api_profile,
+    email_notifications_enabled,
+)
 from pwpush.api.client import normalize_base_url, send_request
 from pwpush.api.endpoints import (
     adapt_file_payload_for_profile,
@@ -405,6 +409,8 @@ pwpush push --secret "https://..." --kind url    # Push as URL
 pwpush push --secret "QR data" --kind qr         # Push as QR code
 pwpush push --secret "data" --passphrase "pass"  # With passphrase
 pwpush push --secret "data" --prompt-passphrase  # Prompt for passphrase
+pwpush push --secret "data" --notify "admin@example.com"      # Notify on access (Pro)
+pwpush push --secret "data" --notify "a@b.com" --notify-locale "es"  # Spanish notifications
 [/code]"""
 
 
@@ -441,6 +447,16 @@ def push(
     kind: str = typer.Option(
         "text",
         help="The kind of push to create. Options: text, url, qr. Default: text",
+    ),
+    notify: str | None = typer.Option(
+        None,
+        "--notify",
+        help="Comma-separated email addresses to notify when this push is accessed. Requires authentication and a Pro instance with email notifications enabled.",
+    ),
+    notify_locale: str | None = typer.Option(
+        None,
+        "--notify-locale",
+        help="Locale for notification emails (e.g., 'en', 'es', 'fr', 'de'). Default: 'en'. Requires --notify to be set.",
     ),
 ) -> None:
     data: dict[str, dict[str, Any]] = {"password": {}}
@@ -570,6 +586,34 @@ def push(
     if passphrase is not None:
         data["password"]["passphrase"] = passphrase
 
+    # Email notification options require authentication
+    if notify or notify_locale:
+        token = user_config["instance"]["token"].strip()
+        if not token or token == "Not Set":
+            rprint(
+                "[red]Error: Email notifications require authentication. "
+                "Run 'pwpush login' or set a token with 'pwpush config set token <token>'.[/red]"
+            )
+            raise typer.Exit(1)
+
+        # Check if email notifications are supported on this instance
+        capabilities = detect_api_capabilities(
+            base_url=user_config["instance"]["url"],
+            email=user_config["instance"]["email"],
+            token=user_config["instance"]["token"],
+            debug=debug_output(),
+        )
+        if email_notifications_enabled(capabilities):
+            if notify:
+                data["password"]["notify_emails_to"] = notify
+            if notify_locale:
+                data["password"]["notify_emails_to_locale"] = notify_locale
+        else:
+            rprint(
+                "[yellow]Warning: Email notifications are not enabled on this instance. "
+                "Options ignored.[/yellow]"
+            )
+
     # Lets add a progressbar to notify the something is happing.
     with Progress(
         SpinnerColumn(),
@@ -616,6 +660,16 @@ def pushFile(
         None,
         help="Reference Note. Encrypted & Visible Only to You. E.g. Employee, Record or Ticket ID etc..  Requires login.",
     ),
+    notify: str | None = typer.Option(
+        None,
+        "--notify",
+        help="Comma-separated email addresses to notify when this file is accessed. Requires authentication and a Pro instance with email notifications enabled.",
+    ),
+    notify_locale: str | None = typer.Option(
+        None,
+        "--notify-locale",
+        help="Locale for notification emails (e.g., 'en', 'es', 'fr', 'de'). Default: 'en'. Requires --notify to be set.",
+    ),
     payload: str = typer.Argument(
         "",
     ),
@@ -628,6 +682,7 @@ def pushFile(
         pwpush push-file data.txt --deletable           # Allow deletion by viewer
         pwpush push-file config.json --retrieval-step   # Require click-through
         pwpush push-file backup.zip --days 7 --views 5  # Custom expiration
+        pwpush push-file doc.pdf --notify "admin@example.com"      # Notify on access (Pro)
     """
     require_api_token("push-file")
     api_profile = current_api_profile()
@@ -667,6 +722,34 @@ def pushFile(
 
     if note:
         data["file_push"]["note"] = note
+
+    # Email notification options require authentication
+    if notify or notify_locale:
+        token = user_config["instance"]["token"].strip()
+        if not token or token == "Not Set":
+            rprint(
+                "[red]Error: Email notifications require authentication. "
+                "Run 'pwpush login' or set a token with 'pwpush config set token <token>'.[/red]"
+            )
+            raise typer.Exit(1)
+
+        # Check if email notifications are supported on this instance
+        capabilities = detect_api_capabilities(
+            base_url=user_config["instance"]["url"],
+            email=user_config["instance"]["email"],
+            token=user_config["instance"]["token"],
+            debug=debug_output(),
+        )
+        if email_notifications_enabled(capabilities):
+            if notify:
+                data["file_push"]["notify_emails_to"] = notify
+            if notify_locale:
+                data["file_push"]["notify_emails_to_locale"] = notify_locale
+        else:
+            rprint(
+                "[yellow]Warning: Email notifications are not enabled on this instance. "
+                "Options ignored.[/yellow]"
+            )
 
     try:
         with open(payload, "rb") as fd:

--- a/pwpush/api/capabilities.py
+++ b/pwpush/api/capabilities.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import requests
 
 from pwpush.api.client import absolute_url
@@ -6,11 +8,17 @@ API_PROFILE_V2 = "v2"
 API_PROFILE_LEGACY = "legacy"
 
 _profile_cache: dict[str, str] = {}
+_capabilities_cache: dict[str, dict[str, Any]] = {}
 
 
 def clear_profile_cache() -> None:
     """Clear profile cache (mainly for tests)."""
     _profile_cache.clear()
+
+
+def clear_capabilities_cache() -> None:
+    """Clear capabilities cache (mainly for tests)."""
+    _capabilities_cache.clear()
 
 
 def detect_api_profile(
@@ -40,3 +48,83 @@ def detect_api_profile(
         _profile_cache[cache_key] = API_PROFILE_LEGACY
 
     return _profile_cache[cache_key]
+
+
+def detect_api_capabilities(
+    *,
+    base_url: str,
+    email: str,
+    token: str,
+    debug: bool = False,
+    force_refresh: bool = False,
+) -> dict[str, Any]:
+    """Detect API version and feature flags from /api/v2/version endpoint.
+
+    Returns a dict with:
+    - api_version: str | None (e.g., "2.1.0")
+    - features: dict[str, bool] (feature flags from the features section)
+
+    The result is cached per base_url to avoid repeated API calls.
+    """
+    cache_key = base_url.rstrip("/")
+    if not force_refresh and cache_key in _capabilities_cache:
+        return _capabilities_cache[cache_key]
+
+    probe_url = absolute_url(base_url, "/api/v2/version")
+    headers: dict[str, str] = {}
+    if token.strip() and token != "Not Set":
+        headers = {"Authorization": f"Bearer {token}"}
+
+    result: dict[str, Any] = {"api_version": None, "features": {}}
+
+    try:
+        response = requests.get(probe_url, headers=headers, timeout=5)
+        if response.status_code == 200:
+            data = response.json()
+            result["api_version"] = data.get("version")
+            result["features"] = data.get("features", {})
+            if debug:
+                print(f"[debug] API capabilities detected: {result}")
+        elif debug:
+            print(f"[debug] API capabilities check failed: {response.status_code}")
+    except requests.exceptions.RequestException as e:
+        if debug:
+            print(f"[debug] API capabilities check error: {e}")
+
+    _capabilities_cache[cache_key] = result
+    return result
+
+
+def email_notifications_enabled(capabilities: dict[str, Any] | None = None) -> bool:
+    """Check if email notifications are supported for pushes.
+
+    Returns True only when:
+    - API version >= 2.1
+    - features.email_auto_dispatch == true
+
+    Args:
+        capabilities: Dict returned by detect_api_capabilities()
+
+    Returns:
+        bool: True if email notifications are enabled on this instance
+    """
+    if not capabilities:
+        return False
+
+    version = capabilities.get("api_version")
+    if not version:
+        return False
+
+    # Parse version string - handle cases like "2.1.0" or "2.1"
+    try:
+        version_parts = version.split(".")
+        major = int(version_parts[0]) if len(version_parts) > 0 else 0
+        minor = int(version_parts[1]) if len(version_parts) > 1 else 0
+
+        if major < 2 or (major == 2 and minor < 1):
+            return False
+    except (ValueError, IndexError):
+        return False
+
+    features = capabilities.get("features", {})
+    return bool(features.get("email_auto_dispatch", False))

--- a/pwpush/api/capabilities.py
+++ b/pwpush/api/capabilities.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import requests
+from rich import print as rprint
 
 from pwpush.api.client import absolute_url
 
@@ -84,12 +85,14 @@ def detect_api_capabilities(
             result["api_version"] = data.get("version")
             result["features"] = data.get("features", {})
             if debug:
-                print(f"[debug] API capabilities detected: {result}")
+                rprint(f"[dim][debug] API capabilities detected: {result}[/dim]")
         elif debug:
-            print(f"[debug] API capabilities check failed: {response.status_code}")
+            rprint(
+                f"[dim][debug] API capabilities check failed: {response.status_code}[/dim]"
+            )
     except requests.exceptions.RequestException as e:
         if debug:
-            print(f"[debug] API capabilities check error: {e}")
+            rprint(f"[dim][debug] API capabilities check error: {e}[/dim]")
 
     _capabilities_cache[cache_key] = result
     return result

--- a/pwpush/api/endpoints.py
+++ b/pwpush/api/endpoints.py
@@ -85,6 +85,10 @@ def adapt_text_payload_for_profile(
         push_payload["retrieval_step"] = source["retrieval_step"]
     if "passphrase" in source:
         push_payload["passphrase"] = source["passphrase"]
+    if "notify_emails_to" in source:
+        push_payload["notify_emails_to"] = source["notify_emails_to"]
+    if "notify_emails_to_locale" in source:
+        push_payload["notify_emails_to_locale"] = source["notify_emails_to_locale"]
 
     if "expire_after_days" in source:
         days = int(source["expire_after_days"])
@@ -117,6 +121,10 @@ def adapt_file_payload_for_profile(
         push_payload["deletable_by_viewer"] = source["deletable_by_viewer"]
     if "retrieval_step" in source:
         push_payload["retrieval_step"] = source["retrieval_step"]
+    if "notify_emails_to" in source:
+        push_payload["notify_emails_to"] = source["notify_emails_to"]
+    if "notify_emails_to_locale" in source:
+        push_payload["notify_emails_to_locale"] = source["notify_emails_to_locale"]
 
     if "expire_after_days" in source:
         days = int(source["expire_after_days"])

--- a/pwpush/commands/config.py
+++ b/pwpush/commands/config.py
@@ -154,6 +154,25 @@ def show(
         console.print(table)
 
         rprint()
+        rprint("[bold]=== Pro Settings:[/bold]")
+        rprint(
+            "Password Pusher Pro features. These require authentication and Pro instance support."
+        )
+        rprint()
+        table = Table("Key", "Value", "Description")
+        table.add_row(
+            "notify",
+            user_config["pro"]["notify"],
+            "Comma-separated emails to notify on push access (Pro feature, requires auth)",
+        )
+        table.add_row(
+            "notify_locale",
+            user_config["pro"]["notify_locale"],
+            "Locale for notification emails (e.g., en, es, fr)",
+        )
+        console.print(table)
+
+        rprint()
         rprint("[bold]=== CLI Settings:[/bold]")
         rprint("Behavior settings for this CLI.")
         rprint()

--- a/pwpush/options.py
+++ b/pwpush/options.py
@@ -33,6 +33,11 @@ default_config["cli"] = {
     "debug": "False",
 }
 
+default_config["pro"] = {
+    "notify": "Not Set",
+    "notify_locale": "Not Set",
+}
+
 
 def config_file_exists() -> bool:
     """
@@ -71,6 +76,9 @@ def validate_user_config() -> bool:
         changed = True
     if "cli" not in user_config:
         user_config["cli"] = {}
+        changed = True
+    if "pro" not in user_config:
+        user_config["pro"] = {}
         changed = True
 
     for section, defaults in default_config.items():

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -24,6 +24,10 @@ def mock_make_request():
     with (
         patch("pwpush.__main__.current_api_profile", return_value="legacy"),
         patch("pwpush.__main__.make_request") as mock,
+        patch(
+            "pwpush.__main__.detect_api_capabilities",
+            return_value={"api_version": None, "features": {}},
+        ),
     ):
         mock.return_value.status_code = 201
         mock.return_value.json.return_value = {

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -266,3 +266,170 @@ def test_push_with_piped_input_explicit_secret(mock_make_request):
     post_call = _get_post_call(mock_make_request)
     assert post_call is not None
     assert post_call[1]["post_data"]["password"]["payload"] == "explicit-secret"
+
+
+def test_push_with_notify_unauthenticated(monkeypatch):
+    """Test that --notify requires authentication - error when no API token."""
+    from pwpush.commands.config import user_config
+
+    # Ensure no token is set
+    monkeypatch.setitem(user_config["instance"], "token", "Not Set")
+
+    with (
+        patch("pwpush.__main__.current_api_profile", return_value="legacy"),
+        patch("pwpush.__main__.make_request") as mock,
+    ):
+        mock.return_value.status_code = 201
+        mock.return_value.json.return_value = {
+            "url_token": "super-token",
+            "url": "https://pwpush.test/en/p/text-password-url",
+        }
+        result = runner.invoke(
+            app, ["push", "--secret", "test", "--notify", "admin@example.com"]
+        )
+    assert result.exit_code == 1
+    assert "Email notifications require authentication" in result.output
+
+
+def test_push_with_notify_locale_unauthenticated(monkeypatch):
+    """Test that --notify-locale requires authentication - error when no API token."""
+    from pwpush.commands.config import user_config
+
+    # Ensure no token is set
+    monkeypatch.setitem(user_config["instance"], "token", "Not Set")
+
+    with (
+        patch("pwpush.__main__.current_api_profile", return_value="legacy"),
+        patch("pwpush.__main__.make_request") as mock,
+    ):
+        mock.return_value.status_code = 201
+        mock.return_value.json.return_value = {
+            "url_token": "super-token",
+            "url": "https://pwpush.test/en/p/text-password-url",
+        }
+        result = runner.invoke(
+            app, ["push", "--secret", "test", "--notify-locale", "en"]
+        )
+    assert result.exit_code == 1
+    assert "Email notifications require authentication" in result.output
+
+
+def test_push_with_notify_when_enabled(mock_make_request, monkeypatch):
+    """Test push with notification when feature is enabled."""
+    # Mock capabilities with feature enabled
+    mock_capabilities = {
+        "api_version": "2.1.0",
+        "features": {"email_auto_dispatch": True},
+    }
+    monkeypatch.setattr(
+        "pwpush.__main__.detect_api_capabilities",
+        lambda **kwargs: mock_capabilities,
+    )
+
+    # Set up auth token
+    from pwpush.commands.config import user_config
+
+    monkeypatch.setitem(user_config["instance"], "token", "valid-token")
+
+    result = runner.invoke(
+        app, ["push", "--secret", "test", "--notify", "admin@example.com"]
+    )
+    assert result.exit_code == 0
+    post_call = _get_post_call(mock_make_request)
+    assert post_call is not None
+    assert (
+        post_call[1]["post_data"]["password"]["notify_emails_to"] == "admin@example.com"
+    )
+
+
+def test_push_with_notify_when_disabled(mock_make_request, monkeypatch):
+    """Test push with notification shows warning when feature is disabled."""
+    # Mock capabilities with feature disabled
+    mock_capabilities = {
+        "api_version": "2.1.0",
+        "features": {"email_auto_dispatch": False},
+    }
+    monkeypatch.setattr(
+        "pwpush.__main__.detect_api_capabilities",
+        lambda **kwargs: mock_capabilities,
+    )
+
+    # Set up auth token
+    from pwpush.commands.config import user_config
+
+    monkeypatch.setitem(user_config["instance"], "token", "valid-token")
+
+    result = runner.invoke(
+        app, ["push", "--secret", "test", "--notify", "admin@example.com"]
+    )
+    assert result.exit_code == 0
+    assert "Email notifications are not enabled" in result.output
+    # Verify notify field is NOT in the payload
+    post_call = _get_post_call(mock_make_request)
+    assert post_call is not None
+    assert "notify_emails_to" not in post_call[1]["post_data"]["password"]
+
+
+def test_push_with_notify_locale(mock_make_request, monkeypatch):
+    """Test push with notification locale."""
+    mock_capabilities = {
+        "api_version": "2.1.0",
+        "features": {"email_auto_dispatch": True},
+    }
+    monkeypatch.setattr(
+        "pwpush.__main__.detect_api_capabilities",
+        lambda **kwargs: mock_capabilities,
+    )
+
+    from pwpush.commands.config import user_config
+
+    monkeypatch.setitem(user_config["instance"], "token", "valid-token")
+
+    result = runner.invoke(
+        app,
+        [
+            "push",
+            "--secret",
+            "test",
+            "--notify",
+            "admin@example.com",
+            "--notify-locale",
+            "es",
+        ],
+    )
+    assert result.exit_code == 0
+    post_call = _get_post_call(mock_make_request)
+    assert post_call is not None
+    assert (
+        post_call[1]["post_data"]["password"]["notify_emails_to"] == "admin@example.com"
+    )
+    assert post_call[1]["post_data"]["password"]["notify_emails_to_locale"] == "es"
+
+
+def test_email_notifications_enabled_helper():
+    """Test the email_notifications_enabled helper function."""
+    from pwpush.api.capabilities import email_notifications_enabled
+
+    # Enabled
+    assert email_notifications_enabled(
+        {"api_version": "2.1.0", "features": {"email_auto_dispatch": True}}
+    )
+
+    # Disabled - feature flag false
+    assert not email_notifications_enabled(
+        {"api_version": "2.1.0", "features": {"email_auto_dispatch": False}}
+    )
+
+    # Disabled - missing feature flag
+    assert not email_notifications_enabled({"api_version": "2.1.0", "features": {}})
+
+    # Disabled - old API version
+    assert not email_notifications_enabled(
+        {"api_version": "2.0.0", "features": {"email_auto_dispatch": True}}
+    )
+
+    # Disabled - None
+    assert not email_notifications_enabled(None)
+
+    # Disabled - empty dict
+    assert not email_notifications_enabled({})


### PR DESCRIPTION
## Summary

This PR adds support for Password Pusher Pro email notification features as requested in #1172.

## New CLI Options

- `--notify`: Comma-separated email addresses to notify when a push is accessed
- `--notify-locale`: Locale for notification emails (e.g., 'en', 'es', 'fr', 'de')

## Usage Examples

```bash
# Notify specific emails when the push is accessed (requires login)
pwpush push --secret "password123" --notify "admin@company.com,security@company.com"

# Set locale for notification emails
pwpush push --secret "password123" --notify "admin@company.com" --notify-locale "en"

# File push with notifications
pwpush push-file document.pdf --notify "admin@company.com"
```

## Requirements

- **Authentication required**: API token must be set via `pwpush login`
- **API version >= 2.1**: The instance must support the v2.1 API
- **Feature enabled**: The `email_auto_dispatch` feature must be enabled on the instance

## Implementation Details

- Added `detect_api_capabilities()` to query `/api/v2/version` for version and feature flags
- Added `email_notifications_enabled()` helper to check API version and `email_auto_dispatch` flag
- Shows **error** (red, exit 1) if user tries to use notification options without authentication
- Shows **warning** (yellow, continue) if authenticated but feature not available on instance
- Updated `adapt_text_payload_for_profile()` and `adapt_file_payload_for_profile()` to include notification fields
- Added Pro settings section to `pwpush config show`
- Added comprehensive tests for all scenarios

## Testing

All 94 tests pass, including 6 new tests:
- `test_push_with_notify_unauthenticated`
- `test_push_with_notify_locale_unauthenticated`
- `test_push_with_notify_when_enabled`
- `test_push_with_notify_when_disabled`
- `test_push_with_notify_locale`
- `test_email_notifications_enabled_helper`

Fixes #1172