### PR TITLE
Fix: Isolate test config from user's real config file

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,29 @@
+"""Pytest configuration and global fixtures."""
+
+import pytest
+
+from pwpush.options import default_config, load_config, user_config
+
+
+@pytest.fixture(autouse=True)
+def isolate_config_file(monkeypatch, tmp_path):
+    """
+    Redirect user_config_file to a temporary path for all tests.
+
+    This prevents tests from reading or writing to the user's real
+    config file at ~/.config/pwpush/config.ini.
+    """
+    config_file = tmp_path / "config.ini"
+
+    # Redirect the config file path in all modules that import it
+    monkeypatch.setattr("pwpush.options.user_config_file", config_file)
+    monkeypatch.setattr("pwpush.commands.config.user_config_file", config_file)
+    monkeypatch.setattr("pwpush.config_wizard.user_config_file", config_file)
+
+    # Clear and reload the config with defaults to ensure clean state
+    user_config.clear()
+    user_config.read_dict(default_config)
+
+    yield config_file
+
+    # Cleanup: the tmp_path will be automatically cleaned up by pytest


### PR DESCRIPTION
## Summary

Adds a global pytest fixture that redirects `user_config_file` to a temporary path for all tests, preventing tests from overwriting the user's real config file at `~/.config/pwpush/config.ini`.

## Problem

When running tests, the global `user_config` object was being modified directly by several tests (e.g., `test_profile_persistence.py`, `test_bug_fixes.py`). When `validate_user_config()` detected changes, it called `save_config()`, which wrote to the real user config file, changing the instance URL back to `https://example.test`.

## Solution

Created `tests/conftest.py` with an `autouse=True` fixture that:
1. Redirects `user_config_file` to a temporary path using `monkeypatch`
2. Patches all modules that import the config file path
3. Clears and reloads `user_config` with defaults before each test
4. Uses pytest's `tmp_path` for automatic cleanup

## Testing

All 94 tests pass with the fixture in place, and the user's real config file is now protected from test overwrites.