### PR TITLE
Fix version display and add --version flag

### DIFF
--- a/pwpush/__init__.py
+++ b/pwpush/__init__.py
@@ -1,7 +1,6 @@
 # mypy: disable-error-code="attr-defined"
 """Command Line Interface to Password Pusher - secure information distribution with automatic expiration controls."""
 
-import sys
 from importlib import metadata as importlib_metadata
 from pathlib import Path
 
@@ -14,7 +13,23 @@ def get_version() -> str:
         try:
             pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
             if pyproject_path.exists():
-                import tomllib
+                # Try tomllib (Python 3.11+) or tomli (Python 3.10)
+                try:
+                    import tomllib
+                except ImportError:
+                    try:
+                        import tomli as tomllib
+                    except ImportError:
+                        # Fallback: simple regex extraction for Python 3.10 without tomli
+                        import re
+
+                        content = pyproject_path.read_text()
+                        match = re.search(
+                            r'^version\s*=\s*"([^"]+)"', content, re.MULTILINE
+                        )
+                        if match:
+                            return match.group(1)
+                        return "unknown"
 
                 with open(pyproject_path, "rb") as f:
                     pyproject_data = tomllib.load(f)

--- a/pwpush/__init__.py
+++ b/pwpush/__init__.py
@@ -3,12 +3,24 @@
 
 import sys
 from importlib import metadata as importlib_metadata
+from pathlib import Path
 
 
 def get_version() -> str:
     try:
         return importlib_metadata.version(__name__)
-    except importlib_metadata.PackageNotFoundError:  # pragma: no cover
+    except importlib_metadata.PackageNotFoundError:
+        # Fallback: read version from pyproject.toml when running from source
+        try:
+            pyproject_path = Path(__file__).parent.parent / "pyproject.toml"
+            if pyproject_path.exists():
+                import tomllib
+
+                with open(pyproject_path, "rb") as f:
+                    pyproject_data = tomllib.load(f)
+                    return pyproject_data.get("project", {}).get("version", "unknown")
+        except Exception:
+            pass
         return "unknown"
 
 

--- a/pwpush/__main__.py
+++ b/pwpush/__main__.py
@@ -302,6 +302,13 @@ def load_cli_options(
         "-h",
         help="Show this message and exit.",
     ),
+    version: bool = typer.Option(
+        False,
+        "--version",
+        callback=version_callback,
+        is_eager=True,
+        help="Show the version and exit.",
+    ),
 ) -> None:
     # CLI Args override configuration
     cli_options["json"] = parse_boolean(json)

--- a/pwpush/__main__.py
+++ b/pwpush/__main__.py
@@ -302,7 +302,7 @@ def load_cli_options(
         "-h",
         help="Show this message and exit.",
     ),
-    version: bool = typer.Option(
+    show_version: bool = typer.Option(
         False,
         "--version",
         callback=version_callback,

--- a/tests/test_bug_fixes.py
+++ b/tests/test_bug_fixes.py
@@ -836,3 +836,51 @@ def test_audit_help_mentions_api_token_requirement() -> None:
 
     assert result.exit_code == 0
     assert "Requires login with an API token." in result.stdout
+
+
+def test_version_flag_prints_version() -> None:
+    """Test --version flag prints version and exits immediately."""
+    result = runner.invoke(app, ["--version"])
+
+    assert result.exit_code == 0
+    assert "pwpush version:" in result.stdout
+    # Should not show welcome screen or prompt for config
+    assert "Password Pusher CLI" not in result.stdout
+    assert "setup wizard" not in result.stdout.lower()
+
+
+def test_version_from_pyproject_toml() -> None:
+    """Test get_version() reads from pyproject.toml when package not installed."""
+    from importlib import metadata as importlib_metadata
+
+    from pwpush import get_version
+
+    with patch.object(
+        importlib_metadata,
+        "version",
+        side_effect=importlib_metadata.PackageNotFoundError,
+    ):
+        version = get_version()
+
+        # Should successfully read version from pyproject.toml
+        assert version != "unknown"
+        assert version.count(".") >= 1  # Basic semver check
+
+
+def test_version_unknown_when_no_package_or_pyproject() -> None:
+    """Test get_version() returns 'unknown' when package not installed and pyproject missing."""
+    from importlib import metadata as importlib_metadata
+
+    from pwpush import get_version
+
+    with (
+        patch.object(
+            importlib_metadata,
+            "version",
+            side_effect=importlib_metadata.PackageNotFoundError,
+        ),
+        patch("pwpush.Path.exists", return_value=False),
+    ):
+        version = get_version()
+
+        assert version == "unknown"


### PR DESCRIPTION
## Summary

Fixed version detection to work correctly when running from source and added a `--version` flag to the CLI.

## Changes

### 1. Fixed version detection (`pwpush/__init__.py`)

The `get_version()` function used `importlib_metadata.version(__name__)` which only works when the package is installed. When running from source (development, CI, or direct execution), it returned `"unknown"`, causing the welcome screen to show `Version unknown`.

**Fix:** Added a fallback that reads the version directly from `pyproject.toml` when the package metadata isn't available.

### 2. Added `--version` flag (`pwpush/__main__.py`)

Added a `--version` option to the app callback using the existing `version_callback` function with `is_eager=True` for immediate exit.

## Testing

```bash
$ pwpush --version
pwpush version: 0.14.0

$ pwpush
🔐 Password Pusher CLI
Version 0.14.0
Server: https://devlab.pwpush.com
...
```

All 94 tests pass.