### PR TITLE
Add existing values as defaults in config wizard

### DIFF
--- a/pwpush/commands/config.py
+++ b/pwpush/commands/config.py
@@ -7,13 +7,14 @@ from rich.table import Table
 
 from pwpush.config_wizard import run_config_wizard
 from pwpush.options import (
+    cli_options,
     default_config,
     json_output,
     save_config,
     user_config,
     user_config_file,
 )
-from pwpush.utils import mask_sensitive_value
+from pwpush.utils import mask_sensitive_value, parse_boolean
 
 app = typer.Typer(
     rich_markup_mode="markdown",
@@ -25,14 +26,51 @@ console = Console()
 
 
 @app.callback(invoke_without_command=True)
-def config_commands(ctx: typer.Context) -> None:
+def config_commands(
+    ctx: typer.Context,
+    json: bool = typer.Option(
+        False,
+        "--json",
+        "-j",
+        help="Output results in JSON format instead of human-readable text.",
+    ),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        "-v",
+        help="Enable verbose output with additional details and progress information.",
+    ),
+    pretty: bool = typer.Option(
+        False,
+        "--pretty",
+        "-p",
+        help="Format JSON output with proper indentation and line breaks.",
+    ),
+    debug: bool = typer.Option(
+        False,
+        "--debug",
+        "-d",
+        help="Enable debug mode with detailed request/response information.",
+    ),
+) -> None:
     """
     Show configuration when no subcommand is provided.
 
     Run `pwpush config wizard` for guided setup.
     """
+    # Only update global CLI options if explicitly set via subcommand
+    # This preserves global options set on the parent app (e.g., pwpush --json config)
+    if json:
+        cli_options["json"] = json
+    if verbose:
+        cli_options["verbose"] = verbose
+    if debug:
+        cli_options["debug"] = debug
+    if pretty:
+        cli_options["pretty"] = pretty
+
     if ctx.invoked_subcommand is None:
-        show()
+        _show_config(use_json=json or cli_options.get("json", False))
 
 
 @app.command()
@@ -68,10 +106,15 @@ def show(
     """
     Show current configuration values.
     """
-    # Check both the local flag and the global CLI options
-    from pwpush.options import cli_options
+    _show_config(json_output_flag)
 
-    if json_output_flag or json_output() or cli_options.get("json", False):
+
+def _show_config(use_json: bool = False) -> None:
+    """
+    Internal function to show configuration values.
+    """
+    # Check both the provided flag and the global CLI options
+    if use_json or json_output() or cli_options.get("json", False):
         # Create a copy of the config sections and mask sensitive values
         config_data = {}
         for section_name in user_config.sections():

--- a/pwpush/commands/config.py
+++ b/pwpush/commands/config.py
@@ -14,7 +14,7 @@ from pwpush.options import (
     user_config,
     user_config_file,
 )
-from pwpush.utils import mask_sensitive_value, parse_boolean
+from pwpush.utils import mask_sensitive_value
 
 app = typer.Typer(
     rich_markup_mode="markdown",
@@ -28,7 +28,7 @@ console = Console()
 @app.callback(invoke_without_command=True)
 def config_commands(
     ctx: typer.Context,
-    json: bool = typer.Option(
+    json_flag: bool = typer.Option(
         False,
         "--json",
         "-j",
@@ -60,8 +60,8 @@ def config_commands(
     """
     # Only update global CLI options if explicitly set via subcommand
     # This preserves global options set on the parent app (e.g., pwpush --json config)
-    if json:
-        cli_options["json"] = json
+    if json_flag:
+        cli_options["json"] = json_flag
     if verbose:
         cli_options["verbose"] = verbose
     if debug:
@@ -70,7 +70,7 @@ def config_commands(
         cli_options["pretty"] = pretty
 
     if ctx.invoked_subcommand is None:
-        _show_config(use_json=json or cli_options.get("json", False))
+        _show_config(use_json=json_flag or cli_options.get("json", False))
 
 
 @app.command()

--- a/pwpush/config_wizard.py
+++ b/pwpush/config_wizard.py
@@ -7,6 +7,7 @@ from rich.table import Table
 
 from pwpush.api.client import normalize_base_url
 from pwpush.options import save_config, user_config, user_config_file
+from pwpush.utils import parse_boolean
 
 NOT_SET = "Not Set"
 
@@ -84,15 +85,19 @@ def choose_instance_url() -> str:
     table.add_row("4", "Custom", "Self-hosted OSS or Pro instance")
     console.print(table)
 
-    # Determine default selection based on existing URL
+    # Determine default selection based on existing URL (normalized for comparison)
     default_choice = "1"
     if existing_url and existing_url != NOT_SET:
+        normalized_existing = normalize_base_url(existing_url)
         for index, choice in enumerate(HOSTED_INSTANCE_CHOICES, start=1):
-            if choice.url == existing_url:
+            if choice.url == normalized_existing:
                 default_choice = str(index)
                 break
         # If not a hosted choice, default to Custom (4)
-        if default_choice == "1" and existing_url != HOSTED_INSTANCE_CHOICES[0].url:
+        if (
+            default_choice == "1"
+            and normalized_existing != HOSTED_INSTANCE_CHOICES[0].url
+        ):
             default_choice = "4"
 
     while True:
@@ -133,7 +138,9 @@ def prompt_optional_int_with_default(
 ) -> str:
     """Prompt for an optional bounded integer config value with an existing default."""
     while True:
-        value = typer.prompt(prompt, default=existing_value, show_default=True).strip()
+        value = typer.prompt(
+            prompt, default=existing_value, show_default=bool(existing_value)
+        ).strip()
         if not value:
             return NOT_SET
 
@@ -158,20 +165,13 @@ def bool_config_value(prompt: str, *, default: bool = False) -> str:
     return str(typer.confirm(prompt, default=default))
 
 
-def parse_bool_config(value: str) -> bool:
-    """Parse a config string value as a boolean."""
-    if value.lower() in ("true", "yes", "1", "on"):
-        return True
-    return False
-
-
 def collect_wizard_settings() -> WizardSettings:
     """Collect all setup wizard settings without mutating global config."""
     url = choose_instance_url()
 
     # Get existing values for API token
     existing_token = user_config["instance"]["token"]
-    has_existing_token = existing_token != NOT_SET and existing_token.strip()
+    has_existing_token = existing_token != NOT_SET and bool(existing_token.strip())
 
     email = NOT_SET
     token = existing_token if has_existing_token else NOT_SET
@@ -250,7 +250,7 @@ def collect_wizard_settings() -> WizardSettings:
         retrieval_step = bool_config_value(
             "Enable retrieval step by default?",
             default=(
-                parse_bool_config(existing_retrieval)
+                parse_boolean(existing_retrieval)
                 if existing_retrieval != NOT_SET
                 else False
             ),
@@ -258,7 +258,7 @@ def collect_wizard_settings() -> WizardSettings:
         deletable_by_viewer = bool_config_value(
             "Allow viewers to delete pushes by default?",
             default=(
-                parse_bool_config(existing_deletable)
+                parse_boolean(existing_deletable)
                 if existing_deletable != NOT_SET
                 else False
             ),
@@ -276,22 +276,21 @@ def collect_wizard_settings() -> WizardSettings:
     debug = existing_debug if existing_debug != NOT_SET else NOT_SET
 
     has_existing_cli = any(
-        parse_bool_config(v)
+        v != NOT_SET
         for v in [existing_json, existing_verbose, existing_pretty, existing_debug]
-        if v != NOT_SET
     )
 
     if typer.confirm("Set CLI output preferences?", default=has_existing_cli):
         json = bool_config_value(
             "Output JSON by default?",
             default=(
-                parse_bool_config(existing_json) if existing_json != NOT_SET else False
+                parse_boolean(existing_json) if existing_json != NOT_SET else False
             ),
         )
         verbose = bool_config_value(
             "Enable verbose output by default?",
             default=(
-                parse_bool_config(existing_verbose)
+                parse_boolean(existing_verbose)
                 if existing_verbose != NOT_SET
                 else False
             ),
@@ -299,17 +298,13 @@ def collect_wizard_settings() -> WizardSettings:
         pretty = bool_config_value(
             "Pretty-print JSON by default?",
             default=(
-                parse_bool_config(existing_pretty)
-                if existing_pretty != NOT_SET
-                else False
+                parse_boolean(existing_pretty) if existing_pretty != NOT_SET else False
             ),
         )
         debug = bool_config_value(
             "Enable debug output by default?",
             default=(
-                parse_bool_config(existing_debug)
-                if existing_debug != NOT_SET
-                else False
+                parse_boolean(existing_debug) if existing_debug != NOT_SET else False
             ),
         )
 

--- a/pwpush/config_wizard.py
+++ b/pwpush/config_wizard.py
@@ -76,25 +76,45 @@ def normalize_instance_url(url: str) -> str:
 
 def choose_instance_url() -> str:
     """Prompt for the Password Pusher instance URL."""
+    existing_url = user_config["instance"]["url"]
+
     table = Table("Option", "Instance", "Description")
     for index, choice in enumerate(HOSTED_INSTANCE_CHOICES, start=1):
         table.add_row(str(index), choice.url, f"{choice.label}: {choice.description}")
     table.add_row("4", "Custom", "Self-hosted OSS or Pro instance")
     console.print(table)
 
+    # Determine default selection based on existing URL
+    default_choice = "1"
+    if existing_url and existing_url != NOT_SET:
+        for index, choice in enumerate(HOSTED_INSTANCE_CHOICES, start=1):
+            if choice.url == existing_url:
+                default_choice = str(index)
+                break
+        # If not a hosted choice, default to Custom (4)
+        if default_choice == "1" and existing_url != HOSTED_INSTANCE_CHOICES[0].url:
+            default_choice = "4"
+
     while True:
-        selection = typer.prompt("Choose an instance", default="1").strip()
+        selection = typer.prompt("Choose an instance", default=default_choice).strip()
         if selection in ("1", "2", "3"):
             return HOSTED_INSTANCE_CHOICES[int(selection) - 1].url
         if selection == "4":
-            return prompt_custom_instance_url()
+            return prompt_custom_instance_url(
+                existing_url if existing_url != NOT_SET else None
+            )
         console.print("[red]Please choose 1, 2, 3, or 4.[/red]")
 
 
-def prompt_custom_instance_url() -> str:
+def prompt_custom_instance_url(existing_url: str | None = None) -> str:
     """Prompt for a custom instance URL until a valid value is provided."""
+    default_url = existing_url if existing_url else ""
     while True:
-        url = typer.prompt("Custom instance URL, e.g. https://pwpush.example.com")
+        url = typer.prompt(
+            "Custom instance URL, e.g. https://pwpush.example.com",
+            default=default_url,
+            show_default=True if existing_url else False,
+        )
         try:
             return normalize_instance_url(url)
         except ValueError as exc:
@@ -103,8 +123,17 @@ def prompt_custom_instance_url() -> str:
 
 def prompt_optional_int(prompt: str, *, minimum: int, maximum: int) -> str:
     """Prompt for an optional bounded integer config value."""
+    return prompt_optional_int_with_default(
+        prompt, existing_value="", minimum=minimum, maximum=maximum
+    )
+
+
+def prompt_optional_int_with_default(
+    prompt: str, *, existing_value: str, minimum: int, maximum: int
+) -> str:
+    """Prompt for an optional bounded integer config value with an existing default."""
     while True:
-        value = typer.prompt(prompt, default="", show_default=False).strip()
+        value = typer.prompt(prompt, default=existing_value, show_default=True).strip()
         if not value:
             return NOT_SET
 
@@ -129,48 +158,160 @@ def bool_config_value(prompt: str, *, default: bool = False) -> str:
     return str(typer.confirm(prompt, default=default))
 
 
+def parse_bool_config(value: str) -> bool:
+    """Parse a config string value as a boolean."""
+    if value.lower() in ("true", "yes", "1", "on"):
+        return True
+    return False
+
+
 def collect_wizard_settings() -> WizardSettings:
     """Collect all setup wizard settings without mutating global config."""
     url = choose_instance_url()
 
-    email = NOT_SET
-    token = NOT_SET
-    if typer.confirm("Do you want to add an API token?", default=False):
-        token = typer.prompt("API token", hide_input=True)
+    # Get existing values for API token
+    existing_token = user_config["instance"]["token"]
+    has_existing_token = existing_token != NOT_SET and existing_token.strip()
 
-    expire_after_days = NOT_SET
-    expire_after_views = NOT_SET
-    retrieval_step = NOT_SET
-    deletable_by_viewer = NOT_SET
-    if typer.confirm("Set default expiration preferences?", default=False):
-        expire_after_days = prompt_optional_int(
+    email = NOT_SET
+    token = existing_token if has_existing_token else NOT_SET
+    if typer.confirm(
+        "Do you want to add an API token?",
+        default=has_existing_token,
+    ):
+        if has_existing_token:
+            # Show masked token and allow updating
+            masked = (
+                existing_token[:4] + "****" + existing_token[-4:]
+                if len(existing_token) > 8
+                else "****"
+            )
+            console.print(
+                f"[dim]Current token: {masked} (press Enter to keep, or type new token)[/dim]"
+            )
+        token_input = typer.prompt(
+            "API token",
+            default=existing_token if has_existing_token else "",
+            show_default=False,
+            hide_input=True,
+        )
+        if token_input.strip():
+            token = token_input
+        else:
+            token = existing_token if has_existing_token else NOT_SET
+
+    # Get existing expiration values
+    existing_expire_days = user_config["expiration"]["expire_after_days"]
+    existing_expire_views = user_config["expiration"]["expire_after_views"]
+    existing_retrieval = user_config["expiration"]["retrieval_step"]
+    existing_deletable = user_config["expiration"]["deletable_by_viewer"]
+
+    has_existing_expiration = any(
+        v != NOT_SET
+        for v in [
+            existing_expire_days,
+            existing_expire_views,
+            existing_retrieval,
+            existing_deletable,
+        ]
+    )
+
+    expire_after_days = (
+        existing_expire_days if existing_expire_days != NOT_SET else NOT_SET
+    )
+    expire_after_views = (
+        existing_expire_views if existing_expire_views != NOT_SET else NOT_SET
+    )
+    retrieval_step = existing_retrieval if existing_retrieval != NOT_SET else NOT_SET
+    deletable_by_viewer = (
+        existing_deletable if existing_deletable != NOT_SET else NOT_SET
+    )
+
+    if typer.confirm(
+        "Set default expiration preferences?", default=has_existing_expiration
+    ):
+        days_default = existing_expire_days if existing_expire_days != NOT_SET else ""
+        views_default = (
+            existing_expire_views if existing_expire_views != NOT_SET else ""
+        )
+
+        expire_after_days = prompt_optional_int_with_default(
             "Default expiration days, 1-90 (blank for server default)",
+            existing_value=days_default,
             minimum=1,
             maximum=90,
         )
-        expire_after_views = prompt_optional_int(
+        expire_after_views = prompt_optional_int_with_default(
             "Default expiration views, 1-100 (blank for server default)",
+            existing_value=views_default,
             minimum=1,
             maximum=100,
         )
         retrieval_step = bool_config_value(
             "Enable retrieval step by default?",
-            default=False,
+            default=(
+                parse_bool_config(existing_retrieval)
+                if existing_retrieval != NOT_SET
+                else False
+            ),
         )
         deletable_by_viewer = bool_config_value(
             "Allow viewers to delete pushes by default?",
-            default=False,
+            default=(
+                parse_bool_config(existing_deletable)
+                if existing_deletable != NOT_SET
+                else False
+            ),
         )
 
-    json = user_config["cli"]["json"]
-    verbose = user_config["cli"]["verbose"]
-    pretty = user_config["cli"]["pretty"]
-    debug = user_config["cli"]["debug"]
-    if typer.confirm("Set CLI output preferences?", default=False):
-        json = bool_config_value("Output JSON by default?", default=False)
-        verbose = bool_config_value("Enable verbose output by default?", default=False)
-        pretty = bool_config_value("Pretty-print JSON by default?", default=False)
-        debug = bool_config_value("Enable debug output by default?", default=False)
+    # Get existing CLI output values
+    existing_json = user_config["cli"]["json"]
+    existing_verbose = user_config["cli"]["verbose"]
+    existing_pretty = user_config["cli"]["pretty"]
+    existing_debug = user_config["cli"]["debug"]
+
+    json = existing_json if existing_json != NOT_SET else NOT_SET
+    verbose = existing_verbose if existing_verbose != NOT_SET else NOT_SET
+    pretty = existing_pretty if existing_pretty != NOT_SET else NOT_SET
+    debug = existing_debug if existing_debug != NOT_SET else NOT_SET
+
+    has_existing_cli = any(
+        parse_bool_config(v)
+        for v in [existing_json, existing_verbose, existing_pretty, existing_debug]
+        if v != NOT_SET
+    )
+
+    if typer.confirm("Set CLI output preferences?", default=has_existing_cli):
+        json = bool_config_value(
+            "Output JSON by default?",
+            default=(
+                parse_bool_config(existing_json) if existing_json != NOT_SET else False
+            ),
+        )
+        verbose = bool_config_value(
+            "Enable verbose output by default?",
+            default=(
+                parse_bool_config(existing_verbose)
+                if existing_verbose != NOT_SET
+                else False
+            ),
+        )
+        pretty = bool_config_value(
+            "Pretty-print JSON by default?",
+            default=(
+                parse_bool_config(existing_pretty)
+                if existing_pretty != NOT_SET
+                else False
+            ),
+        )
+        debug = bool_config_value(
+            "Enable debug output by default?",
+            default=(
+                parse_bool_config(existing_debug)
+                if existing_debug != NOT_SET
+                else False
+            ),
+        )
 
     return WizardSettings(
         url=url,


### PR DESCRIPTION
## Summary

The config wizard now shows existing configured values as defaults, allowing users to press Enter to accept the current value instead of retyping everything.

## Problem

When running `pwpush config wizard` with an existing configuration, users had to:
1. Re-select their instance even if already configured
2. Re-enter their API token even if one was set
3. Re-answer all preference questions without seeing current values

## Solution

### Instance Selection
- Pre-selects the option matching the existing URL (1-3 for hosted, 4 for custom)
- For custom URLs, shows the existing URL as default when prompting

```
┏━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Option ┃ Instance               ┃ Description                                         ┃
┡━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ 1      │ https://eu.pwpush.com  │ EU hosted: Pro features; EU Data Residency          │
│ 2      │ https://us.pwpush.com  │ US hosted: Pro features; US Data Residency          │
│ 3      │ https://oss.pwpush.com │ OSS hosted: OSS; EU Data Residency; No File Uploads │
│ 4      │ Custom                 │ Self-hosted OSS or Pro instance                     │
└────────┴────────────────────────┴─────────────────────────────────────────────────────┘
Choose an instance [2]:     # <-- Defaults to 2 if eu.pwpush.com configured
```

### API Token
- Defaults to "Yes" for adding token if one exists
- Shows masked token (e.g., `abcd****wxyz`) as default
- Press Enter to keep existing, or type new token

```
Do you want to add an API token? [Y/n]: 
Current token: abcd****wxyz (press Enter to keep, or type new token)
API token [abcd****wxyz]:   # <-- Enter keeps existing, or type to replace
```

### Expiration & CLI Preferences
- Pre-fills existing numeric values
- Pre-selects existing boolean values

```
Default expiration days, 1-90 (blank for server default) [7]: 
Enable retrieval step by default? [y/N]:   # <-- Shows Y if enabled, N if not
```

## Changes
- `choose_instance_url()`: Detects existing URL and pre-selects matching option
- `prompt_custom_instance_url()`: Accepts `existing_url` parameter
- `prompt_optional_int_with_default()`: New function with existing value support
- `collect_wizard_settings()`: Reads existing values as defaults
- `parse_bool_config()`: Helper to parse existing config booleans

## Testing
All 99 tests pass.