### PR TITLE
fix(security): restrict config file permissions to owner only

### DIFF
--- a/pwpush/options.py
+++ b/pwpush/options.py
@@ -1,6 +1,7 @@
 from typing import Any
 
 import configparser
+import os
 from pathlib import Path
 
 import typer
@@ -92,11 +93,13 @@ def validate_user_config() -> bool:
 
 def save_config() -> None:
     """
-    Save `user_config` out to file
+    Save `user_config` out to file with restricted permissions (owner read/write only).
     """
     user_config_file.parent.mkdir(parents=True, exist_ok=True)
     with open(user_config_file, "w") as file:
         user_config.write(file)
+    # Restrict permissions to owner read/write only (0o600) to protect API tokens
+    os.chmod(user_config_file, 0o600)
 
 
 def json_output() -> bool:


### PR DESCRIPTION
## Summary

Fixes a security issue where the configuration file containing API tokens was created with default file permissions, potentially allowing other system users to read the credentials.

## Changes

- Added `os.chmod(user_config_file, 0o600)` after writing config file
- Imports `os` module for permission support
- Updated docstring to document the permission behavior

## Security Impact

Sets file permissions to owner read/write only (0o600), protecting API tokens from:
- Other users on shared/multi-user systems
- Accidental exposure via world-readable files

## Testing

All 112 existing tests pass.

Part of QA security review fixes (H2).