### PR TITLE
fix: unreachable code and retry logic in passphrase confirmation

### DIFF
--- a/pwpush/__main__.py
+++ b/pwpush/__main__.py
@@ -559,13 +559,13 @@ def push(
     # Handle --prompt-passphrase flag (explicit passphrase prompting)
     if prompt_passphrase:
         # User provided --prompt-passphrase flag, prompt for it
-        first = None
-        second = None
+        first: str | None = None
+        second: str | None = None
         # Rolling out own here as there is no easy way to prompt with a confirmation and at the same time allow it to be omitted
         while True:
             if first is None:
                 first = getpass.getpass(
-                    "Enter passphrase (If the passphrase it empty if will be omitted): "
+                    "Enter passphrase (If the passphrase is empty, it will be omitted): "
                 )
 
             if first in ("c", "C", ""):
@@ -575,9 +575,13 @@ def push(
             if second is None:
                 second = getpass.getpass("Confirm passphrase: ")
 
-            if first is not None and second is not None and first == second:
+            if first == second:
                 passphrase = first
                 break
+            else:
+                rprint("[red]Passphrases do not match. Please try again.[/red]")
+                first = None
+                second = None
     # If passphrase is None (not provided), leave it as None
     # If passphrase has a value (provided with --passphrase value), use that value
 


### PR DESCRIPTION
## Summary

Fixes a bug in the `--prompt-passphrase` handling where the confirmation loop had unreachable code. Once `first` and `second` passphrases were set but didn't match, there was no way for the user to retry - the loop would continue indefinitely without resetting.

## Changes

- Added proper type annotations (`str | None`) for `first` and `second` variables
- Fixed typo in passphrase prompt ("it empty if will be omitted" → "is empty, it will be omitted")
- Added retry logic: when passphrases don't match, both variables are reset and user can try again
- Simplified the comparison logic by removing redundant `None` checks (already guaranteed by flow)

## Bug Impact

Before this fix:
- If user entered mismatched passphrases, they were stuck in an infinite loop
- No way to correct the mistake without Ctrl+C
- Mypy type errors due to `None` assignment to `str` variables

## Testing

All 112 existing tests pass.

Part of QA review fixes (H3).