### PR TITLE
docs: document intentional str type for CLI boolean options

### DIFF
--- a/pwpush/__main__.py
+++ b/pwpush/__main__.py
@@ -283,6 +283,7 @@ def require_api_token(operation: str) -> None:
 @app.callback(invoke_without_command=True)
 def load_cli_options(
     ctx: typer.Context,
+    # Note: typed as str (not bool) to support both flag style (--json) and value style (--json on)
     json: str = typer.Option(
         False,
         "--json",


### PR DESCRIPTION
## Summary

Documents the intentional use of `str` type (instead of `bool`) for CLI options like `--json`, `--verbose`, `--pretty`, and `--debug`.

## Background

QA review flagged the type annotation as a potential mismatch (M1), but this is actually intentional design.

## Why `str` Type Is Used

The `str` type allows supporting two usage patterns:
1. **Flag style:** `--json` (simple flag, works with any value)
2. **Value style:** `--json on`, `--json true`, `--json yes` (explicit values)

If typed as `bool`, Typer would only support the flag style, breaking backward compatibility for users who pass explicit values.

## Changes

- Added inline comment explaining the design decision
- No functional changes (documentation only)

## Testing

All 112 tests pass.

Documents M1 from QA review.