### PR TITLE
refactor: simplify CLI options to pure boolean flags

### DIFF
--- a/pwpush/__main__.py
+++ b/pwpush/__main__.py
@@ -283,6 +283,7 @@ def require_api_token(operation: str) -> None:
 @app.callback(invoke_without_command=True)
 def load_cli_options(
     ctx: typer.Context,
+    # Note: typed as str (not bool) to support both flag style (--json) and value style (--json on)
     json: str = typer.Option(
         False,
         "--json",

--- a/pwpush/__main__.py
+++ b/pwpush/__main__.py
@@ -283,26 +283,25 @@ def require_api_token(operation: str) -> None:
 @app.callback(invoke_without_command=True)
 def load_cli_options(
     ctx: typer.Context,
-    # Note: typed as str (not bool) to support both flag style (--json) and value style (--json on)
-    json: str = typer.Option(
+    json: bool = typer.Option(
         False,
         "--json",
         "-j",
         help="Output results in JSON format instead of human-readable text.",
     ),
-    verbose: str = typer.Option(
+    verbose: bool = typer.Option(
         False,
         "--verbose",
         "-v",
         help="Enable verbose output with additional details and progress information.",
     ),
-    pretty: str = typer.Option(
+    pretty: bool = typer.Option(
         False,
         "--pretty",
         "-p",
         help="Format JSON output with proper indentation and line breaks.",
     ),
-    debug: str = typer.Option(
+    debug: bool = typer.Option(
         False,
         "--debug",
         "-d",
@@ -323,10 +322,10 @@ def load_cli_options(
     ),
 ) -> None:
     # CLI Args override configuration
-    cli_options["json"] = parse_boolean(json)
-    cli_options["verbose"] = parse_boolean(verbose)
-    cli_options["debug"] = parse_boolean(debug)
-    cli_options["pretty"] = parse_boolean(pretty)
+    cli_options["json"] = json
+    cli_options["verbose"] = verbose
+    cli_options["debug"] = debug
+    cli_options["pretty"] = pretty
 
     # Show welcome screen if no command was provided
     if ctx.invoked_subcommand is None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,7 +68,7 @@ def test_config_show():
 
 
 def test_config_show_in_json():
-    result = runner.invoke(app, ["--json", "on", "config", "show"])
+    result = runner.invoke(app, ["--json", "config", "show"])
     assert '{"instance": {"url":' in result.stdout
     assert result.exit_code == 0
 
@@ -84,7 +84,7 @@ def test_config_set():
     assert "Success" in result.stdout
     assert result.exit_code == 0
 
-    result = runner.invoke(app, ["--json", "on", "config", "show"])
+    result = runner.invoke(app, ["--json", "config", "show"])
     config = json.loads(result.stdout.strip())
     assert config["cli"]["json"] == "True"
     assert config["instance"]["url"] == "https://pwpush.test"
@@ -95,7 +95,7 @@ def test_config_unset():
     assert "Success" in result.stdout
     assert result.exit_code == 0
 
-    result = runner.invoke(app, ["--json", "on", "config", "show"])
+    result = runner.invoke(app, ["--json", "config", "show"])
     config = json.loads(result.stdout.strip())
     assert config["cli"]["json"] == "Not Set"
 
@@ -113,7 +113,7 @@ def test_config_set_positional_arguments():
     assert result.exit_code == 0
 
     # Verify the settings were applied
-    result = runner.invoke(app, ["--json", "on", "config", "show"])
+    result = runner.invoke(app, ["--json", "config", "show"])
     config = json.loads(result.stdout.strip())
     assert config["cli"]["json"] == "True"
     assert config["instance"]["url"] == "https://test-positional.com"
@@ -134,7 +134,7 @@ def test_config_set_flag_arguments():
     assert result.exit_code == 0
 
     # Verify the settings were applied
-    result = runner.invoke(app, ["--json", "on", "config", "show"])
+    result = runner.invoke(app, ["--json", "config", "show"])
     config = json.loads(result.stdout.strip())
     assert config["cli"]["json"] == "False"
     assert config["instance"]["url"] == "https://test-flags.com"
@@ -205,7 +205,7 @@ def test_config_set_expiration_settings():
     assert result.exit_code == 0
 
     # Verify all settings were applied
-    result = runner.invoke(app, ["--json", "on", "config", "show"])
+    result = runner.invoke(app, ["--json", "config", "show"])
     config = json.loads(result.stdout.strip())
     assert config["expiration"]["expire_after_days"] == "7"
     assert config["expiration"]["expire_after_views"] == "10"

--- a/tests/test_config_wizard.py
+++ b/tests/test_config_wizard.py
@@ -188,7 +188,7 @@ def test_config_show_works_without_existing_file(monkeypatch, tmp_path):
     config_file = tmp_path / "config.ini"
     reset_config_file(monkeypatch, config_file)
 
-    result = runner.invoke(app, ["--json", "on", "config", "show"])
+    result = runner.invoke(app, ["--json", "config", "show"])
     config = json.loads(result.stdout.strip())
 
     assert result.exit_code == 0

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -68,7 +68,7 @@ def test_file_push(monkeypatch):
 
 
 def test_config_show_in_json():
-    result = runner.invoke(app, ["--json", "on", "config", "show"])
+    result = runner.invoke(app, ["--json", "config", "show"])
     assert '{"instance": {"url":' in result.stdout
     assert result.exit_code == 0
 


### PR DESCRIPTION
## Summary

Simplifies the CLI by changing `--json`, `--verbose`, `--pretty`, and `--debug` from `str` type to `bool` type. This removes support for explicit values like `--json on` and makes them pure boolean flags.

## Changes

- Changed type annotations from `str` to `bool` in `load_cli_options()`
- Removed `parse_boolean()` calls for CLI options (now direct boolean assignment)
- Updated all tests that used `--json on` to use `--json` instead

## New Behavior

| Before | After |
|--------|-------|
| `--json` or `--json on` | `--json` |
| `--verbose` or `--verbose true` | `--verbose` |
| `--pretty` or `--pretty yes` | `--pretty` |
| `--debug` or `--debug 1` | `--debug` |

## Why This Change

- Simpler code (no `parse_boolean()` needed for CLI flags)
- More predictable CLI behavior
- Follows standard Unix convention where flag presence = true
- Removes confusion about which values are accepted

## Testing

All 112 tests pass.

Replaces the M1 documentation PR with an actual code fix.