### PR TITLE
Add Requests API support for Password Pusher Pro

### DIFF
--- a/.cursor/rules/001-project-overview.mdc
+++ b/.cursor/rules/001-project-overview.mdc
@@ -1,0 +1,76 @@
+# Project Overview: pwpush-cli
+
+description: Essential context about the Password Pusher CLI project structure and architecture
+glob: "**/*.py"
+
+## Project Description
+
+This is a Python CLI tool for Password Pusher - a secure password/secret/file sharing service. The CLI allows users to push secrets with expiration controls to Password Pusher instances.
+
+## Key Technologies
+
+- **Python 3.10+** (minimum requirement)
+- **Typer** - CLI framework with rich output
+- **Rich** - Beautiful terminal output with tables and formatting
+- **Requests** - HTTP client for API communication
+- **Poetry** - Dependency management and packaging
+- **Pytest** - Testing framework with CliRunner for CLI testing
+
+## Project Structure
+
+```
+pwpush-cli/
+├── pwpush/
+│   ├── __init__.py          # Package initialization and version
+│   ├── __main__.py          # Main CLI application entry point (Typer app)
+│   ├── api/
+│   │   ├── capabilities.py  # API feature detection (v2 vs legacy)
+│   │   ├── client.py        # HTTP client with retry logic
+│   │   └── endpoints.py     # API endpoint paths and payload adapters
+│   ├── commands/
+│   │   ├── auth.py          # Login/logout commands
+│   │   ├── config.py        # Configuration management
+│   │   ├── manage.py        # List, audit, expire commands
+│   │   ├── push.py          # Push and push-file commands
+│   │   └── request.py       # Request command (Pro feature)
+│   ├── options.py           # CLI options and user configuration
+│   └── utils.py             # Utility functions (password generation, etc.)
+├── tests/
+│   ├── __init__.py          # Test fixtures and mocks
+│   ├── conftest.py          # Pytest configuration
+│   └── test_*.py            # Test modules
+└── README.md
+```
+
+## Configuration System
+
+User config stored at `~/.config/pwpush/config.ini` with sections:
+- `[instance]`: url, email, token, api_profile, account_id
+- `[expiration]`: expire_after_days, expire_after_views, retrieval_step, deletable_by_viewer
+- `[cli]`: json, verbose, pretty, debug
+- `[pro]`: notify, notify_locale
+
+Config is managed via `configparser.ConfigParser` in `pwpush/options.py`.
+
+## API Compatibility
+
+The CLI auto-negotiates between API v2 and legacy endpoints:
+- Probes `/api/v2/version` on first run
+- Uses **API v2** if available (modern, feature-rich)
+- Falls back to **legacy** endpoints for older instances
+- Caches the result for 1 hour
+
+## Authentication
+
+- Uses `Authorization: Bearer <token>` header
+- Also supports `X-User-Email` and `X-User-Token` for backward compatibility
+- Token required for: push-file, list, audit, expire, request commands
+
+## Pro vs OSS Features
+
+Some features are only available on Password Pusher Pro/Enterprise:
+- `request` command (requires API v2.1+ with commercial edition)
+- Email notifications (`--notify`)
+- Multiple accounts per API token
+
+Always check `capabilities.requests_enabled()` and `capabilities.email_notifications_enabled()` before using Pro features.

--- a/.cursor/rules/002-implementing-commands.mdc
+++ b/.cursor/rules/002-implementing-commands.mdc
@@ -1,0 +1,205 @@
+# Implementing CLI Commands
+
+description: Patterns and best practices for implementing new CLI commands
+glob: "pwpush/commands/*.py"
+
+## Command Module Structure
+
+Each command module follows this pattern:
+
+```python
+"""Command description for module docstring."""
+
+from typing import Any
+import json as json_module
+import typer
+from rich import print as rprint
+from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TextColumn
+
+from pwpush.api.capabilities import detect_api_capabilities, specific_feature_enabled
+from pwpush.api.endpoints import specific_endpoint_functions
+from pwpush.commands.config import user_config
+from pwpush.options import cli_options
+from pwpush.utils import parse_boolean
+
+console = Console()
+
+HELP_TEXT = """Help text with [dim]formatting[/] and [code]examples[/code]."""
+
+
+# Private helper functions for output mode checks
+def _json_output() -> bool:
+    """Check if JSON output is enabled."""
+    user_config_json = parse_boolean(user_config["cli"]["json"])
+    return cli_options["json"] or user_config_json
+
+
+def _pretty_output() -> bool:
+    """Check if pretty output is enabled."""
+    user_config_pretty = parse_boolean(user_config["cli"]["pretty"])
+    return cli_options["pretty"] or user_config_pretty
+
+
+def _debug_output() -> bool:
+    """Check if debug output is enabled."""
+    user_config_debug = parse_boolean(user_config["cli"]["debug"])
+    return cli_options["debug"] or user_config_debug
+
+
+# Private helper to get current API profile
+def _current_api_profile() -> str:
+    """Get the current API profile."""
+    from pwpush.__main__ import current_api_profile
+    return current_api_profile()
+
+
+# Private helper to require API token
+def _require_api_token(operation: str) -> None:
+    """Require a configured API token before authenticated operations."""
+    from pwpush.__main__ import require_api_token
+    require_api_token(operation)
+
+
+# Private helper to make API requests
+def _make_request(method, path, post_data=None, upload_files=None, **kwargs):
+    """Make an API request with the given parameters."""
+    from pwpush.__main__ import make_request
+    return make_request(method, path, post_data=post_data, upload_files=upload_files, **kwargs)
+
+
+# Private helper for CLI options update
+def _update_cli_options(json: bool = False, verbose: bool = False, pretty: bool = False, debug: bool = False) -> None:
+    """Update CLI options from command-line flags."""
+    from pwpush.__main__ import update_cli_options
+    update_cli_options(json=json, verbose=verbose, pretty=pretty, debug=debug)
+
+
+# Private helper for error output
+def _error_json(message: str, status_code: int | None = None) -> None:
+    """Print an error message in JSON format."""
+    from pwpush.__main__ import error_json
+    error_json(message, status_code)
+
+
+# Main command function
+def command_cmd(ctx: typer.Context, ...) -> None:
+    """Main command implementation."""
+    _update_cli_options(json=json, verbose=verbose, pretty=pretty, debug=debug)
+    
+    # Check authentication if required
+    _require_api_token("command-name")
+    
+    # Check API capabilities for Pro features
+    api_profile = _current_api_profile()
+    capabilities = detect_api_capabilities(
+        base_url=user_config["instance"]["url"],
+        email=user_config["instance"]["email"],
+        token=user_config["instance"]["token"],
+        debug=_debug_output(),
+    )
+    
+    if not specific_feature_enabled(capabilities):
+        if _json_output():
+            _error_json("Feature not available...")
+        else:
+            rprint("[red]Error: Feature not available...[/red]")
+        raise typer.Exit(1)
+    
+    # Build payload
+    data: dict[str, dict[str, Any]] = {"resource": {}}
+    data["resource"]["payload"] = ...
+    
+    # Add expiration options from config or CLI
+    if days:
+        data["resource"]["expire_after_days"] = days
+    elif user_config["expiration"]["expire_after_days"] != "Not Set":
+        data["resource"]["expire_after_days"] = user_config["expiration"]["expire_after_days"]
+    
+    # Rate limit callback
+    def on_rate_limit_retry(attempt: int, delay: float, response: Any) -> None:
+        if not _json_output():
+            rprint(f"[yellow]Rate limit exceeded. Retrying in {delay:.1f}s...[/yellow]")
+    
+    # Progress indicator
+    with Progress(SpinnerColumn(), TextColumn("[progress.description]{task.description}"), transient=True) as progress:
+        progress.add_task(description="Processing...", total=None)
+        
+        # Make request
+        response = _make_request("POST", path, post_data=data, on_rate_limit_retry=on_rate_limit_retry)
+    
+    # Handle response
+    if response.status_code == 201:
+        body = response.json()
+        if _json_output():
+            dumps_kwargs: dict[str, Any] = {}
+            if _pretty_output():
+                dumps_kwargs["indent"] = 2
+                dumps_kwargs["sort_keys"] = True
+            print(json_module.dumps(body, **dumps_kwargs))
+        else:
+            rprint(f"Success: {body['url']}")
+    else:
+        error_message = response.text
+        try:
+            error_body = response.json()
+            if isinstance(error_body, dict):
+                error_message = error_body.get("error", response.text)
+        except json_module.JSONDecodeError:
+            pass
+        _error_json(error_message, response.status_code)
+        raise typer.Exit(1)
+```
+
+## Key Patterns
+
+1. **Always use private helper functions** that wrap imports from `__main__` to avoid circular imports
+2. **Always include HELP_TEXT** constant for command help
+3. **Check authentication** with `_require_api_token()` for protected commands
+4. **Check API capabilities** with appropriate `*_enabled()` functions for Pro features
+5. **Use Rich for output** - tables, colors, formatting
+6. **Support JSON output** via `_json_output()` and `_pretty_output()` checks
+7. **Use Progress indicators** for network operations
+8. **Handle rate limits** with `on_rate_limit_retry` callback
+9. **Handle errors gracefully** with proper JSON/text output based on flags
+
+## Command Registration in __main__.py
+
+```python
+@app.command(help=MODULE_HELP_TEXT)
+def command_name(
+    ctx: typer.Context,
+    # Arguments
+    positional_arg: str = typer.Argument("", help="Description"),
+    # Options
+    option_name: str | None = typer.Option(None, "--option", help="Description"),
+    boolean_flag: bool | None = typer.Option(None, "--flag", help="Description"),
+    # Standard output options
+    json: bool = typer.Option(False, "--json", "-j", help="Output results in JSON format."),
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Enable verbose output."),
+    pretty: bool = typer.Option(False, "--pretty", "-p", help="Pretty-print JSON output."),
+    debug: bool = typer.Option(False, "--debug", "-d", help="Enable debug mode."),
+) -> None:
+    """Command description."""
+    command_cmd(ctx=ctx, positional_arg=positional_arg, option_name=option_name, ...)
+```
+
+## Error Handling
+
+Always use `_error_json()` for errors - it handles both JSON and text output modes:
+
+```python
+if error_condition:
+    _error_json("Error message", status_code=400)
+    raise typer.Exit(1)
+```
+
+For authentication errors, use the standard pattern:
+```python
+if token == "Not Set":
+    if _json_output():
+        _error_json("'command' requires an API token. Run 'pwpush login'...")
+    else:
+        rprint("[red]Error: 'command' requires an API token...[/red]")
+    raise typer.Exit(1)
+```

--- a/.cursor/rules/003-api-integration.mdc
+++ b/.cursor/rules/003-api-integration.mdc
@@ -1,0 +1,187 @@
+# API Integration Patterns
+
+description: Patterns for API endpoint paths, payload adapters, and capability detection
+glob: "pwpush/api/*.py"
+
+## API Endpoints Module (endpoints.py)
+
+### Endpoint Path Functions
+
+Create functions that return appropriate paths based on API profile:
+
+```python
+def resource_create_path(api_profile: str) -> str:
+    """Return create endpoint for resource."""
+    if api_profile == API_PROFILE_V2:
+        return "/api/v2/resources"
+    return "/legacy.json"
+
+
+def resource_preview_path(api_profile: str, url_token: str) -> str:
+    """Return preview endpoint for created resource."""
+    if api_profile == API_PROFILE_V2:
+        return f"/api/v2/resources/{url_token}/preview"
+    return f"/legacy/{url_token}/preview.json"
+
+
+def resource_expire_path(api_profile: str, url_token: str) -> str:
+    """Return expire endpoint path."""
+    if api_profile == API_PROFILE_V2:
+        return f"/api/v2/resources/{url_token}"
+    return f"/legacy/{url_token}.json"
+```
+
+### Payload Adapters
+
+Convert between legacy and v2 payload formats:
+
+```python
+def adapt_resource_payload_for_profile(
+    payload: dict[str, Any], api_profile: str
+) -> dict[str, Any]:
+    """Convert resource payload between legacy and v2 formats."""
+    if api_profile == API_PROFILE_LEGACY:
+        return payload
+
+    source = payload["resource"]
+    resource_payload: dict[str, Any] = {
+        "payload": source["payload"],
+    }
+    
+    # Copy optional fields if present
+    if "expire_after_views" in source:
+        resource_payload["expire_after_views"] = source["expire_after_views"]
+    if "note" in source:
+        resource_payload["note"] = source["note"]
+    if "deletable_by_viewer" in source:
+        resource_payload["deletable_by_viewer"] = source["deletable_by_viewer"]
+    if "retrieval_step" in source:
+        resource_payload["retrieval_step"] = source["retrieval_step"]
+
+    # Convert days to duration using _DURATION_BY_DAYS mapping
+    if "expire_after_days" in source:
+        days = int(source["expire_after_days"])
+        if days in _DURATION_BY_DAYS:
+            resource_payload["expire_after_duration"] = _DURATION_BY_DAYS[days]
+        else:
+            resource_payload["expire_after_days"] = days
+
+    return {"resource": resource_payload}
+
+
+def adapt_resource_uploads_for_profile(
+    upload_files: dict[str, Any], api_profile: str
+) -> dict[str, Any]:
+    """Rename multipart file key for v2 when required."""
+    if api_profile == API_PROFILE_LEGACY:
+        return upload_files
+    if "resource[files][]" in upload_files:
+        return {"resource[files][]": upload_files["resource[files][]"]}
+    return upload_files
+```
+
+### Duration Mapping
+
+Use the existing `_DURATION_BY_DAYS` mapping for day-to-duration conversion:
+
+```python
+_DURATION_BY_DAYS = {
+    1: 6,    # 1 day -> duration 6
+    2: 7,    # 2 days -> duration 7
+    3: 8,
+    4: 9,
+    5: 10,
+    6: 11,
+    7: 12,
+    14: 13,
+    21: 14,
+    30: 15,
+    60: 16,
+    90: 17,
+}
+```
+
+## Capabilities Module (capabilities.py)
+
+### Feature Detection Functions
+
+Pattern for adding new feature detection:
+
+```python
+def feature_name_enabled(capabilities: dict[str, Any] | None = None) -> bool:
+    """Check if feature is supported.
+
+    Returns True when:
+    - API version >= required_version
+    - features.feature_name == true (for 2.1+)
+    - features.commercial == true (for Pro features)
+
+    Args:
+        capabilities: Dict returned by detect_api_capabilities()
+
+    Returns:
+        bool: True if feature is enabled on this instance
+    """
+    if not capabilities:
+        return False
+
+    version = capabilities.get("api_version")
+    if not version:
+        return False
+
+    # Parse version string
+    try:
+        version_parts = version.split(".")
+        major = int(version_parts[0]) if len(version_parts) > 0 else 0
+        minor = int(version_parts[1]) if len(version_parts) > 1 else 0
+
+        # Check minimum version requirement
+        if major < 2 or (major == 2 and minor < 1):
+            return False
+    except (ValueError, IndexError):
+        return False
+
+    # For API 2.1+, check the features hash
+    if major == 2 and minor >= 1:
+        features = capabilities.get("features", {})
+        # For Pro features, also check commercial flag
+        is_commercial = bool(features.get("commercial", False))
+        feature_available = bool(features.get("feature_name", False))
+        return is_commercial and feature_available
+
+    return False
+```
+
+### Detecting Capabilities
+
+```python
+# In command implementation
+capabilities = detect_api_capabilities(
+    base_url=user_config["instance"]["url"],
+    email=user_config["instance"]["email"],
+    token=user_config["instance"]["token"],
+    debug=_debug_output(),
+)
+
+if not feature_name_enabled(capabilities):
+    _error_json("Feature not available on this instance")
+    raise typer.Exit(1)
+```
+
+## Pro Feature Requirements
+
+When implementing Pro-only features, ensure:
+
+1. **API version check**: Minimum API v2.0 or v2.1 depending on feature
+2. **Commercial edition check**: Verify `features.commercial == true`
+3. **Feature flag check**: Verify specific feature flag exists and is true
+4. **Authentication**: Always require API token
+5. **Error messages**: Clear messages explaining Pro requirement
+
+Example error message:
+```python
+_error_json(
+    "The Feature API is not available on this instance. "
+    "This feature requires Password Pusher Pro with API version 2.1 or greater."
+)
+```

--- a/.cursor/rules/004-testing-patterns.mdc
+++ b/.cursor/rules/004-testing-patterns.mdc
@@ -1,0 +1,284 @@
+# Testing Patterns
+
+description: Patterns and best practices for writing tests in pwpush-cli
+glob: "tests/*.py"
+
+## Test File Organization
+
+- `tests/__init__.py` - Shared fixtures and mock utilities
+- `tests/conftest.py` - Pytest configuration and global fixtures
+- `tests/test_<module>.py` - Tests for specific modules
+- `tests/test_<feature>_commands.py` - Tests for CLI commands
+
+## Essential Fixtures
+
+### From tests/__init__.py
+
+```python
+@pytest.fixture
+def mock_make_request():
+    """Mock make_request for commands with legacy API profile."""
+    with (
+        patch("pwpush.__main__.current_api_profile", return_value="legacy"),
+        patch("pwpush.__main__.make_request") as mock,
+        patch(
+            "pwpush.commands.push.detect_api_capabilities",
+            return_value={"api_version": None, "features": {}},
+        ),
+    ):
+        mock.return_value.status_code = 201
+        mock.return_value.json.return_value = {
+            "url_token": "test-token",
+            "url": "https://pwpush.test/en/p/test-url",
+        }
+        yield mock
+```
+
+### From tests/conftest.py
+
+```python
+@pytest.fixture(autouse=True)
+def isolate_config_file(monkeypatch, tmp_path):
+    """Redirect user_config_file to a temporary path for all tests."""
+    config_file = tmp_path / "config.ini"
+    monkeypatch.setattr("pwpush.options.user_config_file", config_file)
+    monkeypatch.setattr("pwpush.commands.config.user_config_file", config_file)
+    # Clear and reload config with defaults
+    user_config.clear()
+    user_config.read_dict(default_config)
+    yield config_file
+```
+
+## CLI Command Testing Pattern
+
+```python
+"""Tests for feature commands."""
+
+from unittest.mock import patch
+import pytest
+from typer.testing import CliRunner
+from pwpush.__main__ import app
+from pwpush.commands.config import user_config
+from tests import *
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def mock_feature_enabled():
+    """Mock feature_enabled to return True."""
+    with patch("pwpush.commands.feature.feature_enabled", return_value=True):
+        yield
+
+
+@pytest.fixture
+def mock_feature_disabled():
+    """Mock feature_enabled to return False."""
+    with patch("pwpush.commands.feature.feature_enabled", return_value=False):
+        yield
+
+
+@pytest.fixture
+def mock_feature_make_request():
+    """Mock make_request for feature commands with v2 API profile."""
+    with (
+        patch("pwpush.__main__.current_api_profile", return_value="v2"),
+        patch("pwpush.__main__.make_request") as mock,
+        patch(
+            "pwpush.commands.feature.detect_api_capabilities",
+            return_value={
+                "api_version": "2.1.0",
+                "features": {"commercial": True, "feature_name": True},
+            },
+        ),
+    ):
+        mock.return_value.status_code = 201
+        mock.return_value.json.return_value = {
+            "url_token": "feature-token",
+            "url": "https://pwpush.test/en/f/feature-url",
+        }
+        yield mock
+
+
+def _get_post_call(mock_make_request):
+    """Helper to find the POST call from make_request mock by HTTP method.
+    
+    Returns a tuple of (positional_args, keyword_args) for the POST call.
+    """
+    for call in mock_make_request.call_args_list:
+        args = call[0] if call[0] else ()
+        kwargs = call[1] if call[1] else {}
+        if args and args[0] == "POST":
+            return (args, kwargs)
+        if kwargs.get("method") == "POST":
+            return (args, kwargs)
+    return None
+
+
+def _get_request_data_from_call(post_call):
+    """Extract request data from a mock call."""
+    if post_call is None:
+        return None
+    args, kwargs = post_call
+    return kwargs.get("post_data", {})
+
+
+# Test: Authentication required
+def test_feature_unauthenticated():
+    """Test that feature command requires authentication."""
+    user_config["instance"]["token"] = "Not Set"
+    user_config["instance"]["email"] = "Not Set"
+    
+    result = runner.invoke(app, ["feature", "--arg", "value"])
+    assert result.exit_code == 1
+    assert "'feature' requires an API token" in result.output
+
+
+# Test: Feature not available
+def test_feature_api_not_available(mock_feature_make_request, mock_feature_disabled):
+    """Test error when feature API is not available."""
+    user_config["instance"]["token"] = "valid-token"
+    user_config["instance"]["email"] = "user@example.com"
+    
+    result = runner.invoke(app, ["feature", "--arg", "value"])
+    assert result.exit_code == 1
+    assert "not available" in result.output
+
+
+# Test: Happy path
+def test_feature_success(mock_feature_make_request, mock_feature_enabled):
+    """Test successful feature command."""
+    user_config["instance"]["token"] = "valid-token"
+    user_config["instance"]["email"] = "user@example.com"
+    
+    result = runner.invoke(app, ["feature", "value"])
+    assert result.exit_code == 0
+    assert "Success" in result.output
+
+
+# Test: Verify request data
+def test_feature_request_data(mock_feature_make_request, mock_feature_enabled):
+    """Test that request is made with correct data."""
+    user_config["instance"]["token"] = "valid-token"
+    
+    result = runner.invoke(app, ["feature", "test-value"])
+    assert result.exit_code == 0
+    
+    post_call = _get_post_call(mock_feature_make_request)
+    assert post_call is not None
+    args, kwargs = post_call
+    assert args[1] == "/api/v2/features"  # Check path
+    
+    post_data = _get_request_data_from_call(post_call)
+    assert post_data["resource"]["payload"] == "test-value"
+
+
+# Test: File operations with tmp_path
+def test_feature_with_file(mock_feature_make_request, mock_feature_enabled, tmp_path):
+    """Test feature with file input."""
+    user_config["instance"]["token"] = "valid-token"
+    
+    # Create temp file
+    content_file = tmp_path / "content.txt"
+    content_file.write_text("File content")
+    
+    result = runner.invoke(app, ["feature", "--content", str(content_file)])
+    assert result.exit_code == 0
+
+
+# Test: JSON output
+def test_feature_json_output(mock_feature_make_request, mock_feature_enabled):
+    """Test JSON output mode."""
+    user_config["instance"]["token"] = "valid-token"
+    
+    result = runner.invoke(app, ["feature", "value", "--json"])
+    assert result.exit_code == 0
+    assert '"url":' in result.output
+
+
+# Test: Error handling
+def test_feature_api_error(mock_feature_make_request, mock_feature_enabled):
+    """Test handling of API error response."""
+    user_config["instance"]["token"] = "valid-token"
+    
+    # Mock error response
+    mock_feature_make_request.return_value.status_code = 422
+    mock_feature_make_request.return_value.text = "Error"
+    mock_feature_make_request.return_value.json.return_value = {"error": "Invalid data"}
+    
+    result = runner.invoke(app, ["feature", "value"])
+    assert result.exit_code == 1
+    assert "Invalid data" in result.output
+```
+
+## Testing Capability Detection
+
+```python
+def test_feature_enabled_helper():
+    """Test the feature_enabled helper function."""
+    from pwpush.api.capabilities import feature_enabled
+
+    # Enabled - API 2.1 with feature and commercial
+    assert feature_enabled({
+        "api_version": "2.1.0",
+        "features": {"commercial": True, "feature_name": True},
+    })
+
+    # Disabled - missing commercial
+    assert not feature_enabled({
+        "api_version": "2.1.0",
+        "features": {"commercial": False, "feature_name": True},
+    })
+
+    # Disabled - missing feature flag
+    assert not feature_enabled({
+        "api_version": "2.1.0",
+        "features": {"commercial": True},
+    })
+
+    # Disabled - old API version
+    assert not feature_enabled({
+        "api_version": "1.0.0",
+        "features": {"commercial": True, "feature_name": True},
+    })
+
+    # Disabled - None
+    assert not feature_enabled(None)
+
+    # Disabled - empty dict
+    assert not feature_enabled({})
+```
+
+## Common Test Patterns
+
+### Testing with User Input
+```python
+result = runner.invoke(app, ["command"], input="user-input\n")
+```
+
+### Testing with Piped Input
+```python
+result = runner.invoke(app, ["push"], input="secret-from-stdin")
+```
+
+### Testing Config Options
+```python
+user_config["expiration"]["expire_after_days"] = "7"
+user_config["expiration"]["expire_after_views"] = "10"
+```
+
+### Testing CLI Options
+```python
+result = runner.invoke(app, ["command", "--json", "--pretty"])
+```
+
+## Best Practices
+
+1. **Always mock `detect_api_capabilities`** when testing commands that check features
+2. **Always set auth token** for authenticated commands via `user_config["instance"]["token"]`
+3. **Use `tmp_path`** fixture for file operations
+4. **Use `monkeypatch`** for modifying config values
+5. **Test both success and error cases**
+6. **Test JSON output mode** for all commands
+7. **Test unauthenticated access** for protected commands
+8. **Verify request data** using `_get_post_call()` helper

--- a/.cursor/rules/005-common-pitfalls.mdc
+++ b/.cursor/rules/005-common-pitfalls.mdc
@@ -1,0 +1,214 @@
+# Common Pitfalls and Debugging
+
+description: Common issues and how to avoid them when working on pwpush-cli
+glob: "**/*.py"
+
+## Import Patterns
+
+### Avoid Circular Imports
+
+**Don't import directly from `__main__` at module level:**
+```python
+# BAD - causes circular import
+from pwpush.__main__ import make_request, require_api_token
+
+# GOOD - import inside functions
+from pwpush.__main__ import make_request
+```
+
+**Correct pattern in command modules:**
+```python
+def _make_request(...):
+    from pwpush.__main__ import make_request
+    return make_request(...)
+```
+
+### Config Import
+
+**Always import from `options` or `commands.config`:**
+```python
+# Good
+from pwpush.options import user_config, cli_options
+from pwpush.commands.config import user_config
+```
+
+## Boolean Parsing
+
+Config values are stored as strings. Use `parse_boolean()`:
+
+```python
+# BAD - direct comparison
+if user_config["cli"]["json"]:
+    # Always true for non-empty string "False"!
+
+# GOOD - use parse_boolean
+from pwpush.utils import parse_boolean
+if parse_boolean(user_config["cli"]["json"]):
+    # Correctly handles "True", "true", "yes", "1", etc.
+```
+
+## API Profile Detection
+
+**Don't hardcode API profile checks:**
+```python
+# BAD
+if api_profile == "v2":  # might break if profile name changes
+
+# GOOD
+from pwpush.api.capabilities import API_PROFILE_V2
+if api_profile == API_PROFILE_V2:
+```
+
+## Error Output
+
+**Always use `_error_json()` for errors:**
+```python
+# BAD - manual error output
+if json_mode:
+    print(json.dumps({"error": "message"}))
+else:
+    rprint("[red]Error: message[/red]")
+raise typer.Exit(1)
+
+# GOOD - unified error handling
+_error_json("message", status_code=400)
+raise typer.Exit(1)
+```
+
+## Pro Feature Checks
+
+**Always check both commercial and feature flags:**
+```python
+# BAD - only checks feature
+if features.get("requests"):
+
+# GOOD - checks both commercial and feature
+is_commercial = bool(features.get("commercial", False))
+requests_available = bool(features.get("requests", False))
+return is_commercial and requests_available
+```
+
+## File Handling
+
+**Always handle file cleanup in finally blocks:**
+```python
+# BAD - file handle might not be closed
+upload_files = {"file": open(path, "rb")}
+response = _make_request(..., upload_files=upload_files)
+
+# GOOD - proper cleanup
+upload_files = None
+try:
+    upload_files = {"file": open(path, "rb")}
+    response = _make_request(..., upload_files=upload_files)
+finally:
+    if upload_files:
+        try:
+            upload_files["file"].close()
+        except Exception:
+            pass
+```
+
+## Testing Gotchas
+
+### Mocking `detect_api_capabilities`
+
+**Must mock in the correct module:**
+```python
+# BAD - mocks in wrong location
+patch("pwpush.api.capabilities.detect_api_capabilities")
+
+# GOOD - mocks where it's used
+patch("pwpush.commands.feature.detect_api_capabilities")
+```
+
+### CLI Runner Input
+
+**Use `input` param for stdin, not `args`:**
+```python
+# BAD
+runner.invoke(app, ["push", "secret"])
+
+# GOOD - simulates piped input
+runner.invoke(app, ["push"], input="secret\n")
+```
+
+### Isolating Config
+
+**Tests must not share config state:**
+```python
+# conftest.py handles this automatically with isolate_config_file fixture
+# Always use this pattern in conftest.py
+```
+
+## Debugging Tips
+
+### Enable Debug Mode
+
+```bash
+pwpush --debug <command>
+```
+
+Shows HTTP requests/responses with headers.
+
+### Check API Profile
+
+```python
+# In code
+from pwpush.__main__ import current_api_profile
+print(f"API Profile: {current_api_profile()}")
+```
+
+### Check Capabilities
+
+```python
+# In code
+from pwpush.api.capabilities import detect_api_capabilities
+caps = detect_api_capabilities(
+    base_url=user_config["instance"]["url"],
+    email=user_config["instance"]["email"],
+    token=user_config["instance"]["token"],
+    debug=True,
+)
+print(f"Capabilities: {caps}")
+```
+
+### Test Isolation Issues
+
+If tests fail unexpectedly:
+1. Check if `isolate_config_file` fixture is in `conftest.py`
+2. Verify mocks are patching the correct module path
+3. Clear pytest cache: `rm -rf .pytest_cache`
+
+## Common Error Messages
+
+### "'command' requires an API token"
+- Set token: `pwpush login` or `pwpush config set token <token>`
+- In tests: `user_config["instance"]["token"] = "valid-token"`
+
+### "Feature not available on this instance"
+- Check API version: `detect_api_capabilities()`
+- Verify commercial edition: `features.commercial`
+- Verify feature flag: `features.feature_name`
+
+### "Circular import"
+- Move imports inside functions
+- Use private helper wrappers for `__main__` imports
+
+### "No such file or directory" in tests
+- Use `tmp_path` fixture for file operations
+- Files created in temp directory are auto-cleaned
+
+## Type Checking
+
+**Always use type hints:**
+```python
+def function(param: str | None) -> dict[str, Any]:
+    ...
+```
+
+**Handle mypy errors:**
+```python
+# If mypy complains about untyped dict
+data: dict[str, Any] = {"key": value}
+```

--- a/.cursor/rules/006-quick-reference.mdc
+++ b/.cursor/rules/006-quick-reference.mdc
@@ -1,0 +1,165 @@
+# Quick Reference
+
+description: Quick reference for common tasks and code snippets
+glob: "**/*.py"
+
+## Adding a New CLI Command
+
+1. **Create command module** `pwpush/commands/newcommand.py`:
+   - Copy structure from existing command (e.g., `request.py`)
+   - Implement `newcommand_cmd()` function
+   - Add `HELP_TEXT` constant
+   - Use private helpers for `__main__` imports
+
+2. **Add to `__main__.py`**:
+   - Import `HELP_TEXT` and command function
+   - Register with `@app.command(help=HELP_TEXT)`
+   - Update welcome/help screens if needed
+
+3. **Add API endpoints** (if needed) `pwpush/api/endpoints.py`:
+   - Add `newcommand_create_path()`
+   - Add `newcommand_preview_path()`
+   - Add `adapt_newcommand_payload_for_profile()`
+
+4. **Add capability detection** (if Pro feature) `pwpush/api/capabilities.py`:
+   - Add `newcommand_enabled()` function
+   - Follow pattern of `requests_enabled()`
+
+5. **Add tests** `tests/test_newcommand_commands.py`:
+   - Create fixtures: `mock_newcommand_enabled`, `mock_newcommand_make_request`
+   - Test: unauthenticated, feature unavailable, success cases, JSON output
+   - Add capability tests in `tests/test_api_capabilities.py`
+
+6. **Update README.md**:
+   - Add to Quick Start or Pro Features section
+   - Include usage examples
+
+## Common Code Snippets
+
+### Check Authentication
+```python
+_require_api_token("command-name")
+```
+
+### Check Pro Feature
+```python
+capabilities = detect_api_capabilities(
+    base_url=user_config["instance"]["url"],
+    email=user_config["instance"]["email"],
+    token=user_config["instance"]["token"],
+    debug=_debug_output(),
+)
+if not feature_enabled(capabilities):
+    _error_json("Feature not available")
+    raise typer.Exit(1)
+```
+
+### Make API Request
+```python
+response = _make_request(
+    "POST",
+    path,
+    post_data=data,
+    on_rate_limit_retry=on_rate_limit_retry,
+)
+```
+
+### Progress Indicator
+```python
+with Progress(
+    SpinnerColumn(),
+    TextColumn("[progress.description]{task.description}"),
+    transient=True,
+) as progress:
+    progress.add_task(description="Processing...", total=None)
+    # ... make request
+```
+
+### Handle Response
+```python
+if response.status_code == 201:
+    body = response.json()
+    if _json_output():
+        print(json_module.dumps(body, indent=2 if _pretty_output() else None))
+    else:
+        rprint(f"Success: {body['url']}")
+else:
+    _error_json("Error message", response.status_code)
+    raise typer.Exit(1)
+```
+
+### Error Handling
+```python
+except FileNotFoundError:
+    _error_json(f"File '{path}' not found.")
+    raise typer.Exit(1)
+except PermissionError:
+    _error_json(f"Permission denied accessing '{path}'.")
+    raise typer.Exit(1)
+```
+
+## Testing Snippets
+
+### Basic Command Test
+```python
+def test_command_success(mock_make_request):
+    user_config["instance"]["token"] = "valid-token"
+    result = runner.invoke(app, ["command", "arg"])
+    assert result.exit_code == 0
+```
+
+### JSON Output Test
+```python
+def test_command_json(mock_make_request):
+    user_config["instance"]["token"] = "valid-token"
+    result = runner.invoke(app, ["command", "--json"])
+    assert '"url":' in result.output
+```
+
+### File Test with tmp_path
+```python
+def test_command_with_file(mock_make_request, tmp_path):
+    user_config["instance"]["token"] = "valid-token"
+    file_path = tmp_path / "test.txt"
+    file_path.write_text("content")
+    result = runner.invoke(app, ["command", "--file", str(file_path)])
+    assert result.exit_code == 0
+```
+
+### Verify Request Data
+```python
+def test_command_request_data(mock_make_request):
+    user_config["instance"]["token"] = "valid-token"
+    runner.invoke(app, ["command", "value"])
+    
+    post_call = _get_post_call(mock_make_request)
+    args, kwargs = post_call
+    post_data = kwargs.get("post_data", {})
+    assert post_data["resource"]["field"] == "value"
+```
+
+## Makefile Commands
+
+```bash
+make test        # Run pytest
+make lint        # Run all linting (black, isort, mypy, etc.)
+make codestyle   # Auto-format code
+make check       # Run tests and linting
+```
+
+## Project Standards
+
+- **Line length**: 88 characters (Black default)
+- **Python version**: 3.10+
+- **Type hints**: Required for all functions
+- **Docstrings**: Google style
+- **Tests**: Use pytest with fixtures from `tests/__init__.py`
+- **Error handling**: Use `_error_json()` for consistent output
+- **Output**: Rich console for human, JSON for scripts
+
+## Useful Links
+
+- Password Pusher: https://pwpush.com
+- Documentation: https://docs.pwpush.com
+- Typer docs: https://typer.tiangolo.com
+- Rich docs: https://rich.readthedocs.io

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 **The elegant way to share secrets from the command line.**
 <br>
-Self-destructing links for passwords, files, and sensitive data.
+Self-destructing links for passwords, files, requests, and sensitive data.
 
 [Installation](#installation) • [Quick Start](#quick-start) • [Features](#features) • [Documentation](https://docs.pwpush.com)
 
@@ -93,6 +93,23 @@ $ pwpush push-file secret-document.pdf --days 7
 https://pwpush.com/f/file456token
 ```
 
+### 4. Request Secrets (Pro)
+
+Ask others to send you secrets securely with the request command. Perfect for when you need someone to send you credentials, files, or any sensitive data:
+
+```bash
+$ pwpush request "Please send me the production API key" --notify "devops@company.com"
+Request created successfully:
+https://pwpush.com/r/abc123xyz
+
+# With a file attachment
+$ pwpush request "Send me the signed NDA" --attach-file ./nda-template.pdf --notify "legal@partner.com"
+Request created successfully:
+https://pwpush.com/r/def456uvw
+```
+
+> **Note:** Requests require authentication with a Password Pusher Pro/Enterprise instance (API v2.1+).
+
 ---
 
 ## Why pwpush?
@@ -100,6 +117,7 @@ https://pwpush.com/f/file456token
 ### 🔐 Security First
 - Zero permanent storage — data is encrypted and auto-deleted
 - Full audit trails — see exactly who accessed what and when
+- **Requests** — ask others to send you secrets securely (Pro)
 - Prevent URL scanners with `--retrieval-step`
 
 ### ✨ Developer Experience
@@ -128,6 +146,12 @@ pwpush push --secret "https://staging.example.com" --kind url
 # Push with a reference note (for your records)
 pwpush push --secret "password" --note "AWS Root - Production"
 
+# Request a secret from someone (Pro feature)
+pwpush request "Send me the production API key" --notify "devops@company.com"
+
+# Request with file attachment (Pro feature)
+pwpush request "Send me the signed contract" --attach-file ./template.pdf --notify "vendor@example.com"
+
 # List your active pushes
 pwpush list
 
@@ -151,8 +175,19 @@ pwpush push --secret "password" --notify "admin@company.com"
 # Multi-language notifications
 pwpush push --secret "password" --notify "admin@company.com" --notify-locale "es"
 
+# Create a request for someone to send you a secret (requires API v2.1+ commercial edition)
+pwpush request "Send me the production database password" --notify "colleague@example.com"
+
+# Request with content from a file
+pwpush request --content ./instructions.txt --notify "team@example.com"
+
+# Request with file attachment
+pwpush request "Send me the signed contract" --attach-file ./template.pdf --notify "vendor@example.com"
+
 # Multiple accounts per API token (automatically detected)
 ```
+
+> **Note:** The `request` command requires authentication with a Password Pusher Pro or Enterprise instance running API v2.1 or greater.
 
 ---
 

--- a/pwpush/__main__.py
+++ b/pwpush/__main__.py
@@ -18,6 +18,8 @@ from pwpush.commands.config import save_config, user_config
 from pwpush.commands.manage import audit_cmd, expire_cmd, list_cmd
 from pwpush.commands.push import HELP_TEXT as PUSH_HELP_TEXT
 from pwpush.commands.push import push_cmd, push_file_cmd
+from pwpush.commands.request import HELP_TEXT as REQUEST_HELP_TEXT
+from pwpush.commands.request import request_cmd
 from pwpush.options import cli_options, config_file_exists
 from pwpush.utils import parse_boolean
 
@@ -61,6 +63,9 @@ def show_welcome_screen() -> None:
         "  [cyan]pwpush push --auto[/cyan]             # Auto-generate password"
     )
     console.print("  [cyan]pwpush push-file document.pdf[/cyan]  # Upload a file")
+    console.print(
+        '  [cyan]pwpush request "Send me the API key" --notify user@example.com[/cyan]  # Request a secret (Pro)'
+    )
     console.print(
         "  [cyan]pwpush login[/cyan]                   # Login for advanced features"
     )
@@ -130,6 +135,9 @@ def show_help_with_config() -> None:
     )
     console.print("  [cyan]push[/cyan]        Push a new password, secret note or text")
     console.print("  [cyan]push-file[/cyan]   Push a new file")
+    console.print(
+        "  [cyan]request[/cyan]     Create a request for someone to send you a secret (Pro)"
+    )
     console.print("  [cyan]expire[/cyan]      Expire a push")
     console.print("  [cyan]audit[/cyan]       Show the audit log for the given push")
     console.print("  [cyan]list[/cyan]        List active pushes (if logged in)")
@@ -621,6 +629,74 @@ def list(
     """List active pushes. Requires login with an API token."""
     list_cmd(
         expired=expired,
+        json=json,
+        verbose=verbose,
+        pretty=pretty,
+        debug=debug,
+    )
+
+
+@app.command(help=REQUEST_HELP_TEXT)
+def request(
+    ctx: typer.Context,
+    text: str = typer.Argument(
+        "", help="Request text/content describing what you need."
+    ),
+    content: str | None = typer.Option(
+        None,
+        "--content",
+        help="Read request content from file instead of positional text.",
+    ),
+    attach_file: str | None = typer.Option(
+        None, "--attach-file", help="Attach a file to the request."
+    ),
+    notify: str | None = typer.Option(
+        None,
+        "--notify",
+        help="Email address to notify when this request is fulfilled. Required for requests.",
+    ),
+    notify_locale: str | None = typer.Option(
+        None,
+        "--notify-locale",
+        help="Locale for notification emails (e.g., 'en', 'es', 'fr', 'de'). Only used when --notify is set.",
+    ),
+    days: int | None = typer.Option(None, help="Expire after this many days."),
+    views: int | None = typer.Option(None, help="Expire after this many views."),
+    deletable: bool | None = typer.Option(
+        None, help="Allow users to delete the request once fulfilled."
+    ),
+    retrieval_step: bool | None = typer.Option(
+        None,
+        help="1-click retrieval step: Helps to avoid chat systems and URL scanners from eating up views.",
+    ),
+    note: str | None = typer.Option(
+        None,
+        help="Reference Note. Encrypted & Visible Only to You. E.g. Employee, Record or Ticket ID etc..",
+    ),
+    json: bool = typer.Option(
+        False, "--json", "-j", help="Output results in JSON format."
+    ),
+    verbose: bool = typer.Option(
+        False, "--verbose", "-v", help="Enable verbose output."
+    ),
+    pretty: bool = typer.Option(
+        False, "--pretty", "-p", help="Pretty-print JSON output."
+    ),
+    debug: bool = typer.Option(False, "--debug", "-d", help="Enable debug mode."),
+) -> None:
+    """Create a request for someone to send you a secret. Requires authentication and a Pro instance."""
+    request_cmd(
+        ctx=ctx,
+        text=text,
+        content=content,
+        attach_file=attach_file,
+        notify=notify,
+        notify_locale=notify_locale,
+        days=days,
+        views=views,
+        deletable=deletable,
+        retrieval_step=retrieval_step,
+        note=note,
         json=json,
         verbose=verbose,
         pretty=pretty,

--- a/pwpush/__main__.py
+++ b/pwpush/__main__.py
@@ -673,6 +673,10 @@ def request(
         None,
         help="Reference Note. Encrypted & Visible Only to You. E.g. Employee, Record or Ticket ID etc..",
     ),
+    name: str | None = typer.Option(
+        None,
+        help="A name for the request shown in the dashboard, notifications and emails.",
+    ),
     json: bool = typer.Option(
         False, "--json", "-j", help="Output results in JSON format."
     ),
@@ -697,6 +701,7 @@ def request(
         deletable=deletable,
         retrieval_step=retrieval_step,
         note=note,
+        name=name,
         json=json,
         verbose=verbose,
         pretty=pretty,

--- a/pwpush/api/capabilities.py
+++ b/pwpush/api/capabilities.py
@@ -170,8 +170,8 @@ def request_email_notifications_enabled(
         return False
 
     features = capabilities.get("features", {})
-    requests = features.get("requests", {})
-    return bool(requests.get("email_auto_dispatch", False))
+    request_features = features.get("requests", {})
+    return bool(request_features.get("email_auto_dispatch", False))
 
 
 def accounts_enabled(capabilities: dict[str, Any] | None = None) -> bool:

--- a/pwpush/api/capabilities.py
+++ b/pwpush/api/capabilities.py
@@ -167,3 +167,49 @@ def accounts_enabled(capabilities: dict[str, Any] | None = None) -> bool:
     features = capabilities.get("features", {})
     accounts = features.get("accounts", {})
     return bool(accounts.get("enabled", False))
+
+
+def requests_enabled(capabilities: dict[str, Any] | None = None) -> bool:
+    """Check if requests API is supported.
+
+    Returns True when:
+    - API version >= 2.0
+    - features.requests == true (for 2.1+)
+    - Commercial edition (Pro) instance
+
+    Args:
+        capabilities: Dict returned by detect_api_capabilities()
+
+    Returns:
+        bool: True if requests API is enabled on this instance
+    """
+    if not capabilities:
+        return False
+
+    version = capabilities.get("api_version")
+    if not version:
+        return False
+
+    # Parse version string - handle cases like "2.0.0" or "2.1"
+    try:
+        version_parts = version.split(".")
+        major = int(version_parts[0]) if len(version_parts) > 0 else 0
+        minor = int(version_parts[1]) if len(version_parts) > 1 else 0
+
+        # Requests API requires API version 2.0 or greater
+        if major < 2:
+            return False
+    except (ValueError, IndexError):
+        return False
+
+    # For API 2.1+, check the features hash
+    if major == 2 and minor >= 1:
+        features = capabilities.get("features", {})
+        # Requests requires both commercial edition and requests feature enabled
+        is_commercial = bool(features.get("commercial", False))
+        requests_available = bool(features.get("requests", False))
+        return is_commercial and requests_available
+
+    # For API 2.0 (without features hash), cannot verify commercial edition
+    # Return False to be safe (commercial edition will have 2.1+ with features hash)
+    return False

--- a/pwpush/api/capabilities.py
+++ b/pwpush/api/capabilities.py
@@ -63,6 +63,7 @@ def detect_api_capabilities(
 
     Returns a dict with:
     - api_version: str | None (e.g., "2.1.0")
+    - edition: str | None (e.g., "commercial", "oss")
     - features: dict[str, bool] (feature flags from the features section)
 
     The result is cached per base_url to avoid repeated API calls.
@@ -76,13 +77,14 @@ def detect_api_capabilities(
     if token.strip() and token != "Not Set":
         headers = {"Authorization": f"Bearer {token}"}
 
-    result: dict[str, Any] = {"api_version": None, "features": {}}
+    result: dict[str, Any] = {"api_version": None, "edition": None, "features": {}}
 
     try:
         response = requests.get(probe_url, headers=headers, timeout=5)
         if response.status_code == 200:
             data = response.json()
             result["api_version"] = data.get("api_version")
+            result["edition"] = data.get("edition")
             result["features"] = data.get("features", {})
             if debug:
                 rprint(f"[dim][debug] API capabilities detected: {result}[/dim]")
@@ -174,8 +176,8 @@ def requests_enabled(capabilities: dict[str, Any] | None = None) -> bool:
 
     Returns True when:
     - API version >= 2.0
-    - features.requests == true (for 2.1+)
-    - Commercial edition (Pro) instance
+    - features.requests.enabled == true (for 2.1+)
+    - edition is "commercial" (Pro) instance
 
     Args:
         capabilities: Dict returned by detect_api_capabilities()
@@ -202,12 +204,21 @@ def requests_enabled(capabilities: dict[str, Any] | None = None) -> bool:
     except (ValueError, IndexError):
         return False
 
-    # For API 2.1+, check the features hash
+    # For API 2.1+, check the features hash and edition
     if major == 2 and minor >= 1:
+        # Check edition at root level ("commercial" for Pro)
+        edition = capabilities.get("edition", "")
+        is_commercial = edition == "commercial"
+
+        # Check requests feature - it's a nested object with "enabled" key
         features = capabilities.get("features", {})
-        # Requests requires both commercial edition and requests feature enabled
-        is_commercial = bool(features.get("commercial", False))
-        requests_available = bool(features.get("requests", False))
+        requests_feature = features.get("requests", {})
+        if isinstance(requests_feature, dict):
+            requests_available = bool(requests_feature.get("enabled", False))
+        else:
+            # Fallback for boolean format if API changes
+            requests_available = bool(requests_feature)
+
         return is_commercial and requests_available
 
     # For API 2.0 (without features hash), cannot verify commercial edition

--- a/pwpush/api/capabilities.py
+++ b/pwpush/api/capabilities.py
@@ -105,7 +105,7 @@ def email_notifications_enabled(capabilities: dict[str, Any] | None = None) -> b
 
     Returns True only when:
     - API version >= 2.1
-    - features.email_auto_dispatch == true
+    - features.pushes.email_auto_dispatch == true
 
     Args:
         capabilities: Dict returned by detect_api_capabilities()
@@ -132,7 +132,46 @@ def email_notifications_enabled(capabilities: dict[str, Any] | None = None) -> b
         return False
 
     features = capabilities.get("features", {})
-    return bool(features.get("email_auto_dispatch", False))
+    pushes = features.get("pushes", {})
+    return bool(pushes.get("email_auto_dispatch", False))
+
+
+def request_email_notifications_enabled(
+    capabilities: dict[str, Any] | None = None,
+) -> bool:
+    """Check if email notifications are supported for requests.
+
+    Returns True only when:
+    - API version >= 2.1
+    - features.requests.email_auto_dispatch == true
+
+    Args:
+        capabilities: Dict returned by detect_api_capabilities()
+
+    Returns:
+        bool: True if request email notifications are enabled on this instance
+    """
+    if not capabilities:
+        return False
+
+    version = capabilities.get("api_version")
+    if not version:
+        return False
+
+    # Parse version string - handle cases like "2.1.0" or "2.1"
+    try:
+        version_parts = version.split(".")
+        major = int(version_parts[0]) if len(version_parts) > 0 else 0
+        minor = int(version_parts[1]) if len(version_parts) > 1 else 0
+
+        if major < 2 or (major == 2 and minor < 1):
+            return False
+    except (ValueError, IndexError):
+        return False
+
+    features = capabilities.get("features", {})
+    requests = features.get("requests", {})
+    return bool(requests.get("email_auto_dispatch", False))
 
 
 def accounts_enabled(capabilities: dict[str, Any] | None = None) -> bool:

--- a/pwpush/api/endpoints.py
+++ b/pwpush/api/endpoints.py
@@ -219,7 +219,7 @@ def adapt_request_payload_for_profile(
 
     source = payload["request"]
     request_payload: dict[str, Any] = {
-        "payload": source["payload"],
+        "request": source["request"],
     }
     if "notify_emails_to" in source:
         request_payload["notify_emails_to"] = source["notify_emails_to"]

--- a/pwpush/api/endpoints.py
+++ b/pwpush/api/endpoints.py
@@ -229,6 +229,8 @@ def adapt_request_payload_for_profile(
         request_payload["expire_after_views"] = source["expire_after_views"]
     if "note" in source:
         request_payload["note"] = source["note"]
+    if "name" in source:
+        request_payload["name"] = source["name"]
     if "deletable_by_viewer" in source:
         request_payload["deletable_by_viewer"] = source["deletable_by_viewer"]
     if "retrieval_step" in source:

--- a/pwpush/api/endpoints.py
+++ b/pwpush/api/endpoints.py
@@ -221,8 +221,10 @@ def adapt_request_payload_for_profile(
     request_payload: dict[str, Any] = {
         "payload": source["payload"],
     }
-    if "email" in source:
-        request_payload["email"] = source["email"]
+    if "notify_emails_to" in source:
+        request_payload["notify_emails_to"] = source["notify_emails_to"]
+    if "notify_emails_to_locale" in source:
+        request_payload["notify_emails_to_locale"] = source["notify_emails_to_locale"]
     if "expire_after_views" in source:
         request_payload["expire_after_views"] = source["expire_after_views"]
     if "note" in source:

--- a/pwpush/api/endpoints.py
+++ b/pwpush/api/endpoints.py
@@ -189,3 +189,66 @@ def normalize_audit_events(body: dict[str, Any]) -> list[dict[str, str]]:
             }
         )
     return rows
+
+
+# Request API endpoints
+
+
+def request_create_path(api_profile: str) -> str:
+    """Return create endpoint for requests."""
+    if api_profile == API_PROFILE_V2:
+        return "/api/v2/requests"
+    # Legacy API does not support requests
+    return "/r.json"
+
+
+def request_preview_path(api_profile: str, url_token: str) -> str:
+    """Return preview endpoint for created request."""
+    if api_profile == API_PROFILE_V2:
+        return f"/api/v2/requests/{url_token}/preview"
+    # Legacy API does not support requests
+    return f"/r/{url_token}/preview.json"
+
+
+def adapt_request_payload_for_profile(
+    payload: dict[str, Any], api_profile: str
+) -> dict[str, Any]:
+    """Convert request payload between legacy and v2 formats."""
+    if api_profile == API_PROFILE_LEGACY:
+        return payload
+
+    source = payload["request"]
+    request_payload: dict[str, Any] = {
+        "payload": source["payload"],
+    }
+    if "email" in source:
+        request_payload["email"] = source["email"]
+    if "expire_after_views" in source:
+        request_payload["expire_after_views"] = source["expire_after_views"]
+    if "note" in source:
+        request_payload["note"] = source["note"]
+    if "deletable_by_viewer" in source:
+        request_payload["deletable_by_viewer"] = source["deletable_by_viewer"]
+    if "retrieval_step" in source:
+        request_payload["retrieval_step"] = source["retrieval_step"]
+
+    if "expire_after_days" in source:
+        days = int(source["expire_after_days"])
+        if days in _DURATION_BY_DAYS:
+            request_payload["expire_after_duration"] = _DURATION_BY_DAYS[days]
+        else:
+            # Keep backward value for instances that still accept day-style field
+            request_payload["expire_after_days"] = days
+
+    return {"request": request_payload}
+
+
+def adapt_request_uploads_for_profile(
+    upload_files: dict[str, Any], api_profile: str
+) -> dict[str, Any]:
+    """Rename multipart file key for v2 when required."""
+    if api_profile == API_PROFILE_LEGACY:
+        return upload_files
+    if "request[files][]" in upload_files:
+        return {"request[files][]": upload_files["request[files][]"]}
+    return upload_files

--- a/pwpush/commands/push.py
+++ b/pwpush/commands/push.py
@@ -339,7 +339,7 @@ def push_cmd(
             )
 
     # Callback to show rate limit retry feedback
-    def on_rate_limit_retry(attempt: int, delay: float, response) -> None:
+    def on_rate_limit_retry(attempt: int, delay: float, response: Any) -> None:
         if not _json_output():
             rprint(
                 f"[yellow]Rate limit exceeded. Retrying in {delay:.1f}s (attempt {attempt}/3)...[/yellow]"
@@ -514,7 +514,7 @@ def push_file_cmd(
                 )
 
     # Callback to show rate limit retry feedback
-    def on_rate_limit_retry_file(attempt: int, delay: float, response) -> None:
+    def on_rate_limit_retry_file(attempt: int, delay: float, response: Any) -> None:
         if not _json_output():
             rprint(
                 f"[yellow]Rate limit exceeded. Retrying in {delay:.1f}s (attempt {attempt}/3)...[/yellow]"

--- a/pwpush/commands/request.py
+++ b/pwpush/commands/request.py
@@ -198,7 +198,7 @@ def request_cmd(
 
     # Build the request payload
     data: dict[str, dict[str, Any]] = {"request": {}}
-    data["request"]["payload"] = request_content
+    data["request"]["request"] = request_content
 
     # Add notification email (required for requests)
     # Check if email notifications are supported on this instance

--- a/pwpush/commands/request.py
+++ b/pwpush/commands/request.py
@@ -128,6 +128,7 @@ def request_cmd(
     deletable: bool | None = None,
     retrieval_step: bool | None = None,
     note: str | None = None,
+    name: str | None = None,
     json: bool = False,
     verbose: bool = False,
     pretty: bool = False,
@@ -244,6 +245,9 @@ def request_cmd(
 
     if note:
         data["request"]["note"] = note
+
+    if name:
+        data["request"]["name"] = name
 
     # Callback to show rate limit retry feedback
     def on_rate_limit_retry(attempt: int, delay: float, response: Any) -> None:

--- a/pwpush/commands/request.py
+++ b/pwpush/commands/request.py
@@ -1,0 +1,317 @@
+"""Request commands for pwpush CLI (creating requests for others to send secrets)."""
+
+from typing import Any
+
+import json as json_module
+
+import typer
+from rich import print as rprint
+from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TextColumn
+
+from pwpush.api.capabilities import detect_api_capabilities, requests_enabled
+from pwpush.api.endpoints import (
+    adapt_request_payload_for_profile,
+    adapt_request_uploads_for_profile,
+    request_create_path,
+    request_preview_path,
+)
+from pwpush.commands.config import user_config
+from pwpush.options import cli_options
+from pwpush.utils import parse_boolean
+
+console = Console()
+
+HELP_TEXT = """Create a request for someone to send you a secret.
+
+[dim]Examples:[/]
+[code]
+pwpush request "Send me the production password" --notify "colleague@example.com"
+pwpush request --content ./instructions.txt --notify "team@example.com"
+pwpush request "Send me the signed contract" --attach-file ./template.pdf --notify "vendor@example.com"
+pwpush request "Need the API key" --notify "admin@example.com" --days 7 --views 5
+[/code]"""
+
+
+def _json_output() -> bool:
+    """Check if JSON output is enabled."""
+    user_config_json = parse_boolean(user_config["cli"]["json"])
+    return cli_options["json"] or user_config_json
+
+
+def _pretty_output() -> bool:
+    """Check if pretty output is enabled."""
+    user_config_pretty = parse_boolean(user_config["cli"]["pretty"])
+    return cli_options["pretty"] or user_config_pretty
+
+
+def _debug_output() -> bool:
+    """Check if debug output is enabled."""
+    user_config_debug = parse_boolean(user_config["cli"]["debug"])
+    return cli_options["debug"] or user_config_debug
+
+
+def _current_api_profile() -> str:
+    """Get the current API profile."""
+    from pwpush.__main__ import current_api_profile
+
+    return current_api_profile()
+
+
+def _require_api_token(operation: str) -> None:
+    """Require a configured API token before authenticated operations."""
+    from pwpush.__main__ import require_api_token
+
+    require_api_token(operation)
+
+
+def _make_request(
+    method,
+    path,
+    post_data=None,
+    upload_files=None,
+    *,
+    base_url=None,
+    email=None,
+    token=None,
+    timeout=None,
+    on_rate_limit_retry=None,
+):
+    """Make an API request with the given parameters."""
+    from pwpush.__main__ import make_request
+
+    return make_request(
+        method,
+        path,
+        post_data=post_data,
+        upload_files=upload_files,
+        base_url=base_url,
+        email=email,
+        token=token,
+        timeout=timeout,
+        on_rate_limit_retry=on_rate_limit_retry,
+    )
+
+
+def _update_cli_options(
+    json: bool = False,
+    verbose: bool = False,
+    pretty: bool = False,
+    debug: bool = False,
+) -> None:
+    """Update CLI options from command-line flags."""
+    from pwpush.__main__ import update_cli_options
+
+    update_cli_options(json=json, verbose=verbose, pretty=pretty, debug=debug)
+
+
+def _error_json(message: str, status_code: int | None = None) -> None:
+    """Print an error message in JSON format."""
+    from pwpush.__main__ import error_json
+
+    error_json(message, status_code)
+
+
+def request_cmd(
+    ctx: typer.Context,
+    text: str = "",
+    content: str | None = None,
+    attach_file: str | None = None,
+    notify: str | None = None,
+    notify_locale: str | None = None,
+    days: int | None = None,
+    views: int | None = None,
+    deletable: bool | None = None,
+    retrieval_step: bool | None = None,
+    note: str | None = None,
+    json: bool = False,
+    verbose: bool = False,
+    pretty: bool = False,
+    debug: bool = False,
+) -> None:
+    """Create a request for someone to send you a secret."""
+    _update_cli_options(json=json, verbose=verbose, pretty=pretty, debug=debug)
+
+    # Requests API always requires authentication
+    _require_api_token("request")
+
+    api_profile = _current_api_profile()
+
+    # Check if requests API is available on this instance
+    capabilities = detect_api_capabilities(
+        base_url=user_config["instance"]["url"],
+        email=user_config["instance"]["email"],
+        token=user_config["instance"]["token"],
+        debug=_debug_output(),
+    )
+
+    if not requests_enabled(capabilities):
+        if _json_output():
+            _error_json(
+                "The Requests API is not available on this instance. "
+                "This feature requires Password Pusher Pro with API version 2.0 or greater."
+            )
+        else:
+            rprint(
+                "[red]Error: The Requests API is not available on this instance.[/red]"
+            )
+            rprint(
+                "[red]This feature requires Password Pusher Pro with API version 2.0 or greater.[/red]"
+            )
+        raise typer.Exit(1)
+
+    # Validate content input: either positional text OR --content file (mutually exclusive)
+    if text and content:
+        _error_json(
+            "Cannot specify both positional text and --content file. Choose one."
+        )
+        raise typer.Exit(1)
+
+    # Determine the request payload content
+    request_content = ""
+    if content:
+        # Read content from file
+        try:
+            with open(content, encoding="utf-8") as f:
+                request_content = f.read()
+        except FileNotFoundError:
+            _error_json(f"Content file '{content}' not found.")
+            raise typer.Exit(1)
+        except PermissionError:
+            _error_json(f"Permission denied accessing content file '{content}'.")
+            raise typer.Exit(1)
+        except Exception as e:
+            _error_json(f"Error reading content file '{content}': {str(e)}")
+            raise typer.Exit(1)
+    else:
+        request_content = text
+
+    # Validate that we have some content
+    if not request_content and not attach_file:
+        _error_json("Request must include either text content or a file attachment.")
+        raise typer.Exit(1)
+
+    # Build the request payload
+    data: dict[str, dict[str, Any]] = {"request": {}}
+    data["request"]["payload"] = request_content
+
+    # Add notification email (required for requests)
+    if notify:
+        data["request"]["email"] = notify
+
+    # Add expiration options
+    if days:
+        data["request"]["expire_after_days"] = days
+    elif user_config["expiration"]["expire_after_days"] != "Not Set":
+        data["request"]["expire_after_days"] = user_config["expiration"][
+            "expire_after_days"
+        ]
+
+    if views:
+        data["request"]["expire_after_views"] = views
+    elif user_config["expiration"]["expire_after_views"] != "Not Set":
+        data["request"]["expire_after_views"] = user_config["expiration"][
+            "expire_after_views"
+        ]
+
+    # Add other options
+    if deletable is not None:
+        data["request"]["deletable_by_viewer"] = deletable
+    elif user_config["expiration"]["deletable_by_viewer"] != "Not Set":
+        data["request"]["deletable_by_viewer"] = user_config["expiration"][
+            "deletable_by_viewer"
+        ]
+
+    if retrieval_step is not None:
+        data["request"]["retrieval_step"] = retrieval_step
+    elif user_config["expiration"]["retrieval_step"] != "Not Set":
+        data["request"]["retrieval_step"] = user_config["expiration"]["retrieval_step"]
+
+    if note:
+        data["request"]["note"] = note
+
+    # Callback to show rate limit retry feedback
+    def on_rate_limit_retry(attempt: int, delay: float, response: Any) -> None:
+        if not _json_output():
+            rprint(
+                f"[yellow]Rate limit exceeded. Retrying in {delay:.1f}s (attempt {attempt}/3)...[/yellow]"
+            )
+
+    # Create the request with progress indicator
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        transient=True,
+    ) as progress:
+        progress.add_task(description="Creating request...", total=None)
+
+        create_path = request_create_path(api_profile)
+        request_data = adapt_request_payload_for_profile(data, api_profile)
+
+        # Handle file attachment if provided
+        upload_files = None
+        if attach_file:
+            try:
+                file_handle = open(attach_file, "rb")
+                upload_files = {"request[files][]": file_handle}
+                request_files = adapt_request_uploads_for_profile(
+                    upload_files, api_profile
+                )
+            except FileNotFoundError:
+                _error_json(f"Attachment file '{attach_file}' not found.")
+                raise typer.Exit(1)
+            except PermissionError:
+                _error_json(
+                    f"Permission denied accessing attachment file '{attach_file}'."
+                )
+                raise typer.Exit(1)
+            except Exception as e:
+                _error_json(f"Error reading attachment file '{attach_file}': {str(e)}")
+                raise typer.Exit(1)
+        else:
+            request_files = None
+
+        try:
+            response = _make_request(
+                "POST",
+                create_path,
+                post_data=request_data,
+                upload_files=request_files,
+                on_rate_limit_retry=on_rate_limit_retry,
+            )
+        finally:
+            # Clean up file handle if opened
+            if upload_files and "request[files][]" in upload_files:
+                try:
+                    upload_files["request[files][]"].close()
+                except Exception:
+                    pass
+
+    if response.status_code == 201:
+        body = response.json()
+        preview_path = request_preview_path(api_profile, body["url_token"])
+        response = _make_request(
+            "GET", preview_path, on_rate_limit_retry=on_rate_limit_retry
+        )
+
+        body = response.json()
+        if _json_output():
+            # Respect --pretty flag
+            dumps_kwargs: dict[str, Any] = {}
+            if _pretty_output():
+                dumps_kwargs["indent"] = 2
+                dumps_kwargs["sort_keys"] = True
+            print(json_module.dumps(body, **dumps_kwargs))
+        else:
+            rprint(f"Request created successfully:\n{body['url']}")
+    else:
+        # Safely parse error response
+        error_message = response.text
+        try:
+            error_body = response.json()
+            if isinstance(error_body, dict):
+                error_message = error_body.get("error", response.text)
+        except (json_module.JSONDecodeError, ValueError):
+            pass
+        _error_json(error_message, response.status_code)
+        raise typer.Exit(1)

--- a/pwpush/commands/request.py
+++ b/pwpush/commands/request.py
@@ -11,7 +11,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn
 
 from pwpush.api.capabilities import (
     detect_api_capabilities,
-    email_notifications_enabled,
+    request_email_notifications_enabled,
     requests_enabled,
 )
 from pwpush.api.endpoints import (
@@ -202,7 +202,7 @@ def request_cmd(
     # Add notification email (required for requests)
     # Check if email notifications are supported on this instance
     if notify or notify_locale:
-        if email_notifications_enabled(capabilities):
+        if request_email_notifications_enabled(capabilities):
             if notify:
                 data["request"]["notify_emails_to"] = notify
             if notify_locale:

--- a/pwpush/commands/request.py
+++ b/pwpush/commands/request.py
@@ -9,7 +9,11 @@ from rich import print as rprint
 from rich.console import Console
 from rich.progress import Progress, SpinnerColumn, TextColumn
 
-from pwpush.api.capabilities import detect_api_capabilities, requests_enabled
+from pwpush.api.capabilities import (
+    detect_api_capabilities,
+    email_notifications_enabled,
+    requests_enabled,
+)
 from pwpush.api.endpoints import (
     adapt_request_payload_for_profile,
     adapt_request_uploads_for_profile,
@@ -196,8 +200,19 @@ def request_cmd(
     data["request"]["payload"] = request_content
 
     # Add notification email (required for requests)
-    if notify:
-        data["request"]["email"] = notify
+    # Check if email notifications are supported on this instance
+    if notify or notify_locale:
+        if email_notifications_enabled(capabilities):
+            if notify:
+                data["request"]["notify_emails_to"] = notify
+            if notify_locale:
+                data["request"]["notify_emails_to_locale"] = notify_locale
+        else:
+            if not _json_output():
+                rprint(
+                    "[yellow]Warning: Email notifications are not enabled on this instance. "
+                    "Options ignored.[/yellow]"
+                )
 
     # Add expiration options
     if days:

--- a/tests/test_api_capabilities.py
+++ b/tests/test_api_capabilities.py
@@ -1,12 +1,17 @@
 """Tests for API capability detection."""
 
+from typing import Any
+
 from unittest.mock import MagicMock, patch
 
 from pwpush.api.capabilities import (
     API_PROFILE_LEGACY,
     API_PROFILE_V2,
+    clear_capabilities_cache,
     clear_profile_cache,
+    detect_api_capabilities,
     detect_api_profile,
+    requests_enabled,
 )
 
 
@@ -82,3 +87,163 @@ def test_detect_api_profile_uses_bearer_token_without_email() -> None:
         assert mock_get.call_args.kwargs["headers"] == {
             "Authorization": "Bearer test-token"
         }
+
+
+# Tests for requests_enabled function
+
+
+def test_requests_enabled_with_api_2_1_and_feature_true() -> None:
+    """Test requests_enabled returns True for API 2.1 with commercial and requests enabled."""
+    capabilities: dict[str, Any] = {
+        "api_version": "2.1.0",
+        "features": {"commercial": True, "requests": True},
+    }
+    assert requests_enabled(capabilities) is True
+
+
+def test_requests_enabled_with_api_2_1_and_feature_false() -> None:
+    """Test requests_enabled returns False for API 2.1 with requests disabled."""
+    capabilities: dict[str, Any] = {
+        "api_version": "2.1.0",
+        "features": {"commercial": True, "requests": False},
+    }
+    assert requests_enabled(capabilities) is False
+
+
+def test_requests_enabled_with_api_2_1_no_feature_flag() -> None:
+    """Test requests_enabled returns False for API 2.1 without requests feature flag."""
+    capabilities: dict[str, Any] = {
+        "api_version": "2.1.0",
+        "features": {"commercial": True},
+    }
+    assert requests_enabled(capabilities) is False
+
+
+def test_requests_enabled_with_api_2_1_not_commercial() -> None:
+    """Test requests_enabled returns False for API 2.1 without commercial edition."""
+    capabilities: dict[str, Any] = {
+        "api_version": "2.1.0",
+        "features": {"commercial": False, "requests": True},
+    }
+    assert requests_enabled(capabilities) is False
+
+
+def test_requests_enabled_with_api_2_0() -> None:
+    """Test requests_enabled returns False for API 2.0 (cannot verify commercial edition)."""
+    capabilities: dict[str, Any] = {"api_version": "2.0.0", "features": {}}
+    assert requests_enabled(capabilities) is False
+
+
+def test_requests_enabled_with_api_2_0_no_features() -> None:
+    """Test requests_enabled returns False for API 2.0 without features (cannot verify commercial)."""
+    capabilities: dict[str, Any] = {"api_version": "2.0.0"}
+    assert requests_enabled(capabilities) is False
+
+
+def test_requests_enabled_with_api_1_x() -> None:
+    """Test requests_enabled returns False for API 1.x."""
+    capabilities: dict[str, Any] = {
+        "api_version": "1.0.0",
+        "features": {"commercial": True, "requests": True},
+    }
+    assert requests_enabled(capabilities) is False
+
+
+def test_requests_enabled_with_legacy_profile() -> None:
+    """Test requests_enabled returns False for legacy API."""
+    capabilities: dict[str, Any] = {"api_version": None, "features": {}}
+    assert requests_enabled(capabilities) is False
+
+
+def test_requests_enabled_with_none() -> None:
+    """Test requests_enabled returns False for None."""
+    assert requests_enabled(None) is False
+
+
+def test_requests_enabled_with_empty_dict() -> None:
+    """Test requests_enabled returns False for empty dict."""
+    assert requests_enabled({}) is False
+
+
+def test_requests_enabled_with_invalid_version() -> None:
+    """Test requests_enabled returns False for invalid version string."""
+    capabilities = {"api_version": "invalid", "features": {"requests": True}}
+    assert requests_enabled(capabilities) is False
+
+
+def test_requests_enabled_with_api_2_2() -> None:
+    """Test requests_enabled works with API 2.2+ with commercial edition."""
+    capabilities: dict[str, Any] = {
+        "api_version": "2.5.0",
+        "features": {"commercial": True, "requests": True},
+    }
+    assert requests_enabled(capabilities) is True
+
+
+# Tests for detect_api_capabilities
+
+
+def test_detect_api_capabilities_returns_version_and_features() -> None:
+    """Test detect_api_capabilities returns version and features."""
+    clear_capabilities_cache()
+    with patch("pwpush.api.capabilities.requests.get") as mock_get:
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {
+            "api_version": "2.1.0",
+            "features": {"requests": True, "email_auto_dispatch": False},
+        }
+        mock_get.return_value = response
+
+        capabilities = detect_api_capabilities(
+            base_url="https://example.test",
+            email="Not Set",
+            token="Not Set",
+        )
+
+        assert capabilities["api_version"] == "2.1.0"
+        assert capabilities["features"]["requests"] is True
+        assert capabilities["features"]["email_auto_dispatch"] is False
+
+
+def test_detect_api_capabilities_caches_results() -> None:
+    """Test detect_api_capabilities caches results per base_url."""
+    clear_capabilities_cache()
+    with patch("pwpush.api.capabilities.requests.get") as mock_get:
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"api_version": "2.1.0", "features": {}}
+        mock_get.return_value = response
+
+        first = detect_api_capabilities(
+            base_url="https://example.test",
+            email="Not Set",
+            token="Not Set",
+        )
+        second = detect_api_capabilities(
+            base_url="https://example.test",
+            email="Not Set",
+            token="Not Set",
+        )
+
+        assert first["api_version"] == "2.1.0"
+        assert second["api_version"] == "2.1.0"
+        assert mock_get.call_count == 1  # Should be cached
+
+
+def test_detect_api_capabilities_returns_empty_on_404() -> None:
+    """Test detect_api_capabilities returns empty features on 404."""
+    clear_capabilities_cache()
+    with patch("pwpush.api.capabilities.requests.get") as mock_get:
+        response = MagicMock()
+        response.status_code = 404
+        mock_get.return_value = response
+
+        capabilities = detect_api_capabilities(
+            base_url="https://example.test",
+            email="Not Set",
+            token="Not Set",
+        )
+
+        assert capabilities["api_version"] is None
+        assert capabilities["features"] == {}

--- a/tests/test_api_capabilities.py
+++ b/tests/test_api_capabilities.py
@@ -93,10 +93,11 @@ def test_detect_api_profile_uses_bearer_token_without_email() -> None:
 
 
 def test_requests_enabled_with_api_2_1_and_feature_true() -> None:
-    """Test requests_enabled returns True for API 2.1 with commercial and requests enabled."""
+    """Test requests_enabled returns True for API 2.1 with commercial edition and requests enabled."""
     capabilities: dict[str, Any] = {
         "api_version": "2.1.0",
-        "features": {"commercial": True, "requests": True},
+        "edition": "commercial",
+        "features": {"requests": {"enabled": True}},
     }
     assert requests_enabled(capabilities) is True
 
@@ -105,16 +106,18 @@ def test_requests_enabled_with_api_2_1_and_feature_false() -> None:
     """Test requests_enabled returns False for API 2.1 with requests disabled."""
     capabilities: dict[str, Any] = {
         "api_version": "2.1.0",
-        "features": {"commercial": True, "requests": False},
+        "edition": "commercial",
+        "features": {"requests": {"enabled": False}},
     }
     assert requests_enabled(capabilities) is False
 
 
 def test_requests_enabled_with_api_2_1_no_feature_flag() -> None:
-    """Test requests_enabled returns False for API 2.1 without requests feature flag."""
+    """Test requests_enabled returns False for API 2.1 without requests feature."""
     capabilities: dict[str, Any] = {
         "api_version": "2.1.0",
-        "features": {"commercial": True},
+        "edition": "commercial",
+        "features": {},
     }
     assert requests_enabled(capabilities) is False
 
@@ -123,7 +126,8 @@ def test_requests_enabled_with_api_2_1_not_commercial() -> None:
     """Test requests_enabled returns False for API 2.1 without commercial edition."""
     capabilities: dict[str, Any] = {
         "api_version": "2.1.0",
-        "features": {"commercial": False, "requests": True},
+        "edition": "oss",
+        "features": {"requests": {"enabled": True}},
     }
     assert requests_enabled(capabilities) is False
 
@@ -144,14 +148,19 @@ def test_requests_enabled_with_api_1_x() -> None:
     """Test requests_enabled returns False for API 1.x."""
     capabilities: dict[str, Any] = {
         "api_version": "1.0.0",
-        "features": {"commercial": True, "requests": True},
+        "edition": "commercial",
+        "features": {"requests": {"enabled": True}},
     }
     assert requests_enabled(capabilities) is False
 
 
 def test_requests_enabled_with_legacy_profile() -> None:
     """Test requests_enabled returns False for legacy API."""
-    capabilities: dict[str, Any] = {"api_version": None, "features": {}}
+    capabilities: dict[str, Any] = {
+        "api_version": None,
+        "edition": "commercial",
+        "features": {},
+    }
     assert requests_enabled(capabilities) is False
 
 
@@ -167,7 +176,11 @@ def test_requests_enabled_with_empty_dict() -> None:
 
 def test_requests_enabled_with_invalid_version() -> None:
     """Test requests_enabled returns False for invalid version string."""
-    capabilities = {"api_version": "invalid", "features": {"requests": True}}
+    capabilities: dict[str, Any] = {
+        "api_version": "invalid",
+        "edition": "commercial",
+        "features": {"requests": {"enabled": True}},
+    }
     assert requests_enabled(capabilities) is False
 
 
@@ -175,7 +188,18 @@ def test_requests_enabled_with_api_2_2() -> None:
     """Test requests_enabled works with API 2.2+ with commercial edition."""
     capabilities: dict[str, Any] = {
         "api_version": "2.5.0",
-        "features": {"commercial": True, "requests": True},
+        "edition": "commercial",
+        "features": {"requests": {"enabled": True}},
+    }
+    assert requests_enabled(capabilities) is True
+
+
+def test_requests_enabled_with_boolean_fallback() -> None:
+    """Test requests_enabled handles boolean format for backward compatibility."""
+    capabilities: dict[str, Any] = {
+        "api_version": "2.1.0",
+        "edition": "commercial",
+        "features": {"requests": True},  # Boolean format fallback
     }
     assert requests_enabled(capabilities) is True
 

--- a/tests/test_api_capabilities.py
+++ b/tests/test_api_capabilities.py
@@ -204,6 +204,56 @@ def test_requests_enabled_with_boolean_fallback() -> None:
     assert requests_enabled(capabilities) is True
 
 
+# Tests for request_email_notifications_enabled function
+
+
+def test_request_email_notifications_enabled_true() -> None:
+    """Test request_email_notifications_enabled returns True when enabled."""
+    from pwpush.api.capabilities import request_email_notifications_enabled
+
+    capabilities: dict[str, Any] = {
+        "api_version": "2.1.0",
+        "edition": "commercial",
+        "features": {"requests": {"enabled": True, "email_auto_dispatch": True}},
+    }
+    assert request_email_notifications_enabled(capabilities) is True
+
+
+def test_request_email_notifications_enabled_false() -> None:
+    """Test request_email_notifications_enabled returns False when disabled."""
+    from pwpush.api.capabilities import request_email_notifications_enabled
+
+    capabilities: dict[str, Any] = {
+        "api_version": "2.1.0",
+        "edition": "commercial",
+        "features": {"requests": {"enabled": True, "email_auto_dispatch": False}},
+    }
+    assert request_email_notifications_enabled(capabilities) is False
+
+
+def test_request_email_notifications_enabled_missing() -> None:
+    """Test request_email_notifications_enabled returns False when missing."""
+    from pwpush.api.capabilities import request_email_notifications_enabled
+
+    capabilities: dict[str, Any] = {
+        "api_version": "2.1.0",
+        "edition": "commercial",
+        "features": {"requests": {"enabled": True}},
+    }
+    assert request_email_notifications_enabled(capabilities) is False
+
+
+def test_request_email_notifications_enabled_old_api() -> None:
+    """Test request_email_notifications_enabled returns False for old API."""
+    from pwpush.api.capabilities import request_email_notifications_enabled
+
+    capabilities: dict[str, Any] = {
+        "api_version": "2.0.0",
+        "features": {"requests": {"email_auto_dispatch": True}},
+    }
+    assert request_email_notifications_enabled(capabilities) is False
+
+
 # Tests for detect_api_capabilities
 
 

--- a/tests/test_api_v2.py
+++ b/tests/test_api_v2.py
@@ -108,28 +108,37 @@ class TestEmailNotificationsEnabled:
         """Test version parsing with various edge cases."""
         # Version with only major.minor (no patch)
         assert email_notifications_enabled(
-            {"api_version": "2.1", "features": {"email_auto_dispatch": True}}
+            {
+                "api_version": "2.1",
+                "features": {"pushes": {"email_auto_dispatch": True}},
+            }
         )
 
         # Version with extra parts
         assert email_notifications_enabled(
-            {"api_version": "2.1.0.1", "features": {"email_auto_dispatch": True}}
+            {
+                "api_version": "2.1.0.1",
+                "features": {"pushes": {"email_auto_dispatch": True}},
+            }
         )
 
         # Invalid version string
         assert not email_notifications_enabled(
-            {"api_version": "not-a-version", "features": {"email_auto_dispatch": True}}
+            {
+                "api_version": "not-a-version",
+                "features": {"pushes": {"email_auto_dispatch": True}},
+            }
         )
 
         # Empty version
         assert not email_notifications_enabled(
-            {"api_version": "", "features": {"email_auto_dispatch": True}}
+            {"api_version": "", "features": {"pushes": {"email_auto_dispatch": True}}}
         )
 
     def test_missing_api_version(self):
         """Test when api_version is missing."""
         assert not email_notifications_enabled(
-            {"features": {"email_auto_dispatch": True}}
+            {"features": {"pushes": {"email_auto_dispatch": True}}}
         )
 
     def test_missing_features(self):

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -318,10 +318,10 @@ def test_push_with_notify_locale_unauthenticated(monkeypatch):
 
 def test_push_with_notify_when_enabled(mock_make_request, monkeypatch):
     """Test push with notification when feature is enabled."""
-    # Mock capabilities with feature enabled
+    # Mock capabilities with feature enabled - pushes.email_auto_dispatch
     mock_capabilities = {
         "api_version": "2.1.0",
-        "features": {"email_auto_dispatch": True},
+        "features": {"pushes": {"email_auto_dispatch": True}},
     }
     monkeypatch.setattr(
         "pwpush.commands.push.detect_api_capabilities",
@@ -346,10 +346,10 @@ def test_push_with_notify_when_enabled(mock_make_request, monkeypatch):
 
 def test_push_with_notify_when_disabled(mock_make_request, monkeypatch):
     """Test push with notification shows warning when feature is disabled."""
-    # Mock capabilities with feature disabled
+    # Mock capabilities with feature disabled - pushes.email_auto_dispatch
     mock_capabilities = {
         "api_version": "2.1.0",
-        "features": {"email_auto_dispatch": False},
+        "features": {"pushes": {"email_auto_dispatch": False}},
     }
     monkeypatch.setattr(
         "pwpush.commands.push.detect_api_capabilities",
@@ -376,7 +376,7 @@ def test_push_with_notify_locale(mock_make_request, monkeypatch):
     """Test push with notification locale."""
     mock_capabilities = {
         "api_version": "2.1.0",
-        "features": {"email_auto_dispatch": True},
+        "features": {"pushes": {"email_auto_dispatch": True}},
     }
     monkeypatch.setattr(
         "pwpush.commands.push.detect_api_capabilities",
@@ -412,22 +412,27 @@ def test_email_notifications_enabled_helper():
     """Test the email_notifications_enabled helper function."""
     from pwpush.api.capabilities import email_notifications_enabled
 
-    # Enabled
+    # Enabled - pushes.email_auto_dispatch
     assert email_notifications_enabled(
-        {"api_version": "2.1.0", "features": {"email_auto_dispatch": True}}
+        {"api_version": "2.1.0", "features": {"pushes": {"email_auto_dispatch": True}}}
     )
 
     # Disabled - feature flag false
     assert not email_notifications_enabled(
-        {"api_version": "2.1.0", "features": {"email_auto_dispatch": False}}
+        {"api_version": "2.1.0", "features": {"pushes": {"email_auto_dispatch": False}}}
     )
 
-    # Disabled - missing feature flag
+    # Disabled - missing pushes section
     assert not email_notifications_enabled({"api_version": "2.1.0", "features": {}})
+
+    # Disabled - missing email_auto_dispatch in pushes
+    assert not email_notifications_enabled(
+        {"api_version": "2.1.0", "features": {"pushes": {}}}
+    )
 
     # Disabled - old API version
     assert not email_notifications_enabled(
-        {"api_version": "2.0.0", "features": {"email_auto_dispatch": True}}
+        {"api_version": "2.0.0", "features": {"pushes": {"email_auto_dispatch": True}}}
     )
 
     # Disabled - None

--- a/tests/test_request_commands.py
+++ b/tests/test_request_commands.py
@@ -352,6 +352,33 @@ def test_request_with_note(mock_request_make_request, mock_request_enabled):
     assert post_data["request"]["note"] == "Ticket #12345"
 
 
+def test_request_with_name(mock_request_make_request, mock_request_enabled):
+    """Test creating a request with a name."""
+    # Set up auth token
+    user_config["instance"]["token"] = "valid-token"
+    user_config["instance"]["email"] = "user@example.com"
+
+    result = runner.invoke(
+        app,
+        [
+            "request",
+            "Send me the API key",
+            "--notify",
+            "admin@example.com",
+            "--name",
+            "API Key Request",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Request created successfully" in result.output
+
+    # Verify name was passed
+    post_call = _get_post_call(mock_request_make_request)
+    assert post_call is not None
+    post_data = _get_request_data_from_call(post_call)
+    assert post_data["request"]["name"] == "API Key Request"
+
+
 def test_request_json_output(mock_request_make_request, mock_request_enabled):
     """Test request command with JSON output."""
     # Set up auth token

--- a/tests/test_request_commands.py
+++ b/tests/test_request_commands.py
@@ -174,7 +174,7 @@ def test_request_with_content_file(
     post_call = _get_post_call(mock_request_make_request)
     assert post_call is not None
     post_data = _get_request_data_from_call(post_call)
-    assert post_data["request"]["payload"] == "This is the request content from file"
+    assert post_data["request"]["request"] == "This is the request content from file"
     assert post_data["request"]["notify_emails_to"] == "team@example.com"
 
 
@@ -267,7 +267,7 @@ def test_request_with_content_file_and_attach_file(
     post_call = _get_post_call(mock_request_make_request)
     assert post_call is not None
     post_data = _get_request_data_from_call(post_call)
-    assert post_data["request"]["payload"] == "Please fill out this form"
+    assert post_data["request"]["request"] == "Please fill out this form"
     assert post_data["request"]["notify_emails_to"] == "hr@example.com"
     args, kwargs = post_call
     assert kwargs.get("upload_files") is not None

--- a/tests/test_request_commands.py
+++ b/tests/test_request_commands.py
@@ -1,0 +1,545 @@
+"""Tests for request commands."""
+
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from pwpush.__main__ import app
+from pwpush.commands.config import user_config
+
+# import the mocks
+from tests import *
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def mock_request_enabled():
+    """Mock requests_enabled to return True."""
+    with patch(
+        "pwpush.commands.request.requests_enabled",
+        return_value=True,
+    ):
+        yield
+
+
+@pytest.fixture
+def mock_request_disabled():
+    """Mock requests_enabled to return False."""
+    with patch(
+        "pwpush.commands.request.requests_enabled",
+        return_value=False,
+    ):
+        yield
+
+
+@pytest.fixture
+def mock_request_make_request():
+    """Mock make_request for request commands with v2 API profile."""
+    with (
+        patch("pwpush.__main__.current_api_profile", return_value="v2"),
+        patch("pwpush.__main__.make_request") as mock,
+        patch(
+            "pwpush.commands.request.detect_api_capabilities",
+            return_value={
+                "api_version": "2.1.0",
+                "features": {"commercial": True, "requests": True},
+            },
+        ),
+    ):
+        mock.return_value.status_code = 201
+        mock.return_value.json.return_value = {
+            "url_token": "request-token",
+            "url": "https://pwpush.test/en/r/request-url",
+        }
+        yield mock
+
+
+def _get_post_call(mock_make_request):
+    """Helper to find the POST call from make_request mock by HTTP method.
+
+    Returns a tuple of (positional_args, keyword_args) for the POST call.
+    """
+    for call in mock_make_request.call_args_list:
+        args = call[0] if call[0] else ()
+        kwargs = call[1] if call[1] else {}
+        # Check if this is a POST call (first positional arg is method)
+        if args and args[0] == "POST":
+            return (args, kwargs)
+        # Also check kwargs for method
+        if kwargs.get("method") == "POST":
+            return (args, kwargs)
+    return None
+
+
+def _get_request_data_from_call(post_call):
+    """Extract request data from a mock call.
+
+    Handles both positional and keyword argument formats.
+    """
+    if post_call is None:
+        return None
+    args, kwargs = post_call
+    # post_data is passed as a keyword argument
+    return kwargs.get("post_data", {})
+
+
+def test_request_unauthenticated():
+    """Test that request command requires authentication."""
+    # Ensure no token is set
+    user_config["instance"]["token"] = "Not Set"
+    user_config["instance"]["email"] = "Not Set"
+
+    result = runner.invoke(
+        app, ["request", "Send me the password", "--notify", "user@example.com"]
+    )
+    assert result.exit_code == 1
+    assert "'request' requires an API token" in result.output
+
+
+def test_request_api_not_available(mock_request_make_request, mock_request_disabled):
+    """Test error when Requests API is not available on the instance."""
+    # Set up auth token
+    user_config["instance"]["token"] = "valid-token"
+    user_config["instance"]["email"] = "user@example.com"
+
+    result = runner.invoke(
+        app, ["request", "Send me the password", "--notify", "user@example.com"]
+    )
+    assert result.exit_code == 1
+    assert "Requests API is not available" in result.output
+    assert "Password Pusher Pro with API version 2.0 or greater" in result.output
+
+
+def test_request_with_positional_text(mock_request_make_request, mock_request_enabled):
+    """Test creating a request with positional text argument."""
+    # Set up auth token
+    user_config["instance"]["token"] = "valid-token"
+    user_config["instance"]["email"] = "user@example.com"
+
+    result = runner.invoke(
+        app,
+        [
+            "request",
+            "Please send me the production database password",
+            "--notify",
+            "admin@example.com",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Request created successfully" in result.output
+    assert "https://pwpush.test/en/r/request-url" in result.output
+
+    # Verify the POST request was made with correct data
+    post_call = _get_post_call(mock_request_make_request)
+    assert post_call is not None
+    # path is the second positional argument
+    args, kwargs = post_call
+    assert args[1] == "/api/v2/requests"
+    post_data = _get_request_data_from_call(post_call)
+    assert (
+        post_data["request"]["payload"]
+        == "Please send me the production database password"
+    )
+    assert post_data["request"]["email"] == "admin@example.com"
+
+
+def test_request_with_content_file(
+    mock_request_make_request, mock_request_enabled, tmp_path
+):
+    """Test creating a request with --content file option."""
+    # Set up auth token
+    user_config["instance"]["token"] = "valid-token"
+    user_config["instance"]["email"] = "user@example.com"
+
+    # Create a temporary content file
+    content_file = tmp_path / "request_content.txt"
+    content_file.write_text("This is the request content from file")
+
+    result = runner.invoke(
+        app, ["request", "--content", str(content_file), "--notify", "team@example.com"]
+    )
+    assert result.exit_code == 0
+    assert "Request created successfully" in result.output
+
+    # Verify the POST request was made with file content
+    post_call = _get_post_call(mock_request_make_request)
+    assert post_call is not None
+    post_data = _get_request_data_from_call(post_call)
+    assert post_data["request"]["payload"] == "This is the request content from file"
+    assert post_data["request"]["email"] == "team@example.com"
+
+
+def test_request_with_both_text_and_content_error(
+    mock_request_make_request, mock_request_enabled
+):
+    """Test that providing both positional text and --content file results in error."""
+    # Set up auth token
+    user_config["instance"]["token"] = "valid-token"
+    user_config["instance"]["email"] = "user@example.com"
+
+    result = runner.invoke(
+        app,
+        [
+            "request",
+            "positional text",
+            "--content",
+            "/some/file.txt",
+            "--notify",
+            "user@example.com",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "Cannot specify both positional text and --content file" in result.output
+
+
+def test_request_with_attach_file(
+    mock_request_make_request, mock_request_enabled, tmp_path
+):
+    """Test creating a request with a file attachment."""
+    # Set up auth token
+    user_config["instance"]["token"] = "valid-token"
+    user_config["instance"]["email"] = "user@example.com"
+
+    # Create a temporary attachment file
+    attach_file = tmp_path / "template.pdf"
+    attach_file.write_bytes(b"PDF file content")
+
+    result = runner.invoke(
+        app,
+        [
+            "request",
+            "Send me the signed contract",
+            "--attach-file",
+            str(attach_file),
+            "--notify",
+            "vendor@example.com",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Request created successfully" in result.output
+
+    # Verify the POST request was made with file attachment
+    post_call = _get_post_call(mock_request_make_request)
+    assert post_call is not None
+    args, kwargs = post_call
+    assert kwargs.get("upload_files") is not None
+
+
+def test_request_with_content_file_and_attach_file(
+    mock_request_make_request, mock_request_enabled, tmp_path
+):
+    """Test creating a request with both content file and attachment."""
+    # Set up auth token
+    user_config["instance"]["token"] = "valid-token"
+    user_config["instance"]["email"] = "user@example.com"
+
+    # Create temporary files
+    content_file = tmp_path / "instructions.txt"
+    content_file.write_text("Please fill out this form")
+    attach_file = tmp_path / "form.pdf"
+    attach_file.write_bytes(b"Form PDF content")
+
+    result = runner.invoke(
+        app,
+        [
+            "request",
+            "--content",
+            str(content_file),
+            "--attach-file",
+            str(attach_file),
+            "--notify",
+            "hr@example.com",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Request created successfully" in result.output
+
+    # Verify the POST request
+    post_call = _get_post_call(mock_request_make_request)
+    assert post_call is not None
+    post_data = _get_request_data_from_call(post_call)
+    assert post_data["request"]["payload"] == "Please fill out this form"
+    assert post_data["request"]["email"] == "hr@example.com"
+    args, kwargs = post_call
+    assert kwargs.get("upload_files") is not None
+
+
+def test_request_no_content_or_attachment_error(
+    mock_request_make_request, mock_request_enabled
+):
+    """Test that request without content or attachment results in error."""
+    # Set up auth token
+    user_config["instance"]["token"] = "valid-token"
+    user_config["instance"]["email"] = "user@example.com"
+
+    result = runner.invoke(app, ["request", "", "--notify", "user@example.com"])
+    assert result.exit_code == 1
+    assert (
+        "Request must include either text content or a file attachment" in result.output
+    )
+
+
+def test_request_with_expiration_options(
+    mock_request_make_request, mock_request_enabled
+):
+    """Test creating a request with expiration options."""
+    # Set up auth token
+    user_config["instance"]["token"] = "valid-token"
+    user_config["instance"]["email"] = "user@example.com"
+
+    result = runner.invoke(
+        app,
+        [
+            "request",
+            "Need the API key",
+            "--notify",
+            "admin@example.com",
+            "--days",
+            "7",
+            "--views",
+            "5",
+            "--deletable",
+            "--retrieval-step",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Request created successfully" in result.output
+
+    # Verify expiration options were passed
+    post_call = _get_post_call(mock_request_make_request)
+    assert post_call is not None
+    post_data = _get_request_data_from_call(post_call)
+    # Days is converted to duration by the adapter (7 days -> 12)
+    assert post_data["request"]["expire_after_duration"] == 12
+    assert post_data["request"]["expire_after_views"] == 5
+    assert post_data["request"]["deletable_by_viewer"] is True
+    assert post_data["request"]["retrieval_step"] is True
+
+
+def test_request_with_note(mock_request_make_request, mock_request_enabled):
+    """Test creating a request with a reference note."""
+    # Set up auth token
+    user_config["instance"]["token"] = "valid-token"
+    user_config["instance"]["email"] = "user@example.com"
+
+    result = runner.invoke(
+        app,
+        [
+            "request",
+            "Send me the database credentials",
+            "--notify",
+            "devops@example.com",
+            "--note",
+            "Ticket #12345",
+        ],
+    )
+    assert result.exit_code == 0
+    assert "Request created successfully" in result.output
+
+    # Verify note was passed
+    post_call = _get_post_call(mock_request_make_request)
+    assert post_call is not None
+    post_data = _get_request_data_from_call(post_call)
+    assert post_data["request"]["note"] == "Ticket #12345"
+
+
+def test_request_json_output(mock_request_make_request, mock_request_enabled):
+    """Test request command with JSON output."""
+    # Set up auth token
+    user_config["instance"]["token"] = "valid-token"
+    user_config["instance"]["email"] = "user@example.com"
+
+    result = runner.invoke(
+        app, ["request", "Test request", "--notify", "user@example.com", "--json"]
+    )
+    assert result.exit_code == 0
+    # Should output JSON
+    assert '"url":' in result.output
+    assert '"url_token":' in result.output
+
+
+def test_request_json_pretty_output(mock_request_make_request, mock_request_enabled):
+    """Test request command with pretty JSON output."""
+    # Set up auth token
+    user_config["instance"]["token"] = "valid-token"
+    user_config["instance"]["email"] = "user@example.com"
+
+    result = runner.invoke(
+        app,
+        [
+            "request",
+            "Test request",
+            "--notify",
+            "user@example.com",
+            "--json",
+            "--pretty",
+        ],
+    )
+    assert result.exit_code == 0
+    # Pretty JSON should have indentation
+    assert "{\n" in result.output
+
+
+def test_request_content_file_not_found(
+    mock_request_make_request, mock_request_enabled
+):
+    """Test error when content file does not exist."""
+    # Set up auth token
+    user_config["instance"]["token"] = "valid-token"
+    user_config["instance"]["email"] = "user@example.com"
+
+    result = runner.invoke(
+        app,
+        [
+            "request",
+            "--content",
+            "/nonexistent/file.txt",
+            "--notify",
+            "user@example.com",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "Content file" in result.output
+    assert "not found" in result.output
+
+
+def test_request_attach_file_not_found(mock_request_make_request, mock_request_enabled):
+    """Test error when attachment file does not exist."""
+    # Set up auth token
+    user_config["instance"]["token"] = "valid-token"
+    user_config["instance"]["email"] = "user@example.com"
+
+    result = runner.invoke(
+        app,
+        [
+            "request",
+            "Test request",
+            "--attach-file",
+            "/nonexistent/attach.pdf",
+            "--notify",
+            "user@example.com",
+        ],
+    )
+    assert result.exit_code == 1
+    assert "Attachment file" in result.output
+    assert "not found" in result.output
+
+
+def test_request_api_error(mock_request_make_request, mock_request_enabled):
+    """Test handling of API error response."""
+    # Set up auth token
+    user_config["instance"]["token"] = "valid-token"
+    user_config["instance"]["email"] = "user@example.com"
+
+    # Mock an error response
+    mock_request_make_request.return_value.status_code = 422
+    mock_request_make_request.return_value.text = "Unprocessable Entity"
+    mock_request_make_request.return_value.json.return_value = {
+        "error": "Invalid request data"
+    }
+
+    result = runner.invoke(
+        app, ["request", "Test request", "--notify", "user@example.com"]
+    )
+    assert result.exit_code == 1
+    assert "Invalid request data" in result.output
+
+
+def test_request_uses_config_expiration_defaults(
+    mock_request_make_request, mock_request_enabled
+):
+    """Test that request uses expiration defaults from config when not specified."""
+    # Set up auth token
+    user_config["instance"]["token"] = "valid-token"
+    user_config["instance"]["email"] = "user@example.com"
+
+    # Set config defaults
+    user_config["expiration"]["expire_after_days"] = "14"
+    user_config["expiration"]["expire_after_views"] = "10"
+    user_config["expiration"]["deletable_by_viewer"] = "true"
+    user_config["expiration"]["retrieval_step"] = "true"
+
+    result = runner.invoke(
+        app, ["request", "Test request with defaults", "--notify", "user@example.com"]
+    )
+    assert result.exit_code == 0
+
+    # Verify defaults were applied
+    post_call = _get_post_call(mock_request_make_request)
+    assert post_call is not None
+    post_data = _get_request_data_from_call(post_call)
+    # 14 days is in the _DURATION_BY_DAYS mapping (14 -> 13)
+    assert post_data["request"]["expire_after_duration"] == 13
+    # Config values are strings, stored as-is before adapter
+    assert post_data["request"]["expire_after_views"] == "10"
+    assert post_data["request"]["deletable_by_viewer"] == "true"
+    assert post_data["request"]["retrieval_step"] == "true"
+
+
+def test_requests_enabled_helper():
+    """Test the requests_enabled helper function."""
+    from pwpush.api.capabilities import requests_enabled
+
+    # Enabled - API 2.1 with commercial and requests feature flag
+    assert requests_enabled(
+        {
+            "api_version": "2.1.0",
+            "features": {"commercial": True, "requests": True},
+        }
+    )
+
+    # Enabled - API 2.2+ with commercial and requests feature flag
+    assert requests_enabled(
+        {
+            "api_version": "2.5.0",
+            "features": {"commercial": True, "requests": True},
+        }
+    )
+
+    # Disabled - requests feature flag false
+    assert not requests_enabled(
+        {
+            "api_version": "2.1.0",
+            "features": {"commercial": True, "requests": False},
+        }
+    )
+
+    # Disabled - missing requests feature flag on 2.1+
+    assert not requests_enabled(
+        {"api_version": "2.1.0", "features": {"commercial": True}}
+    )
+
+    # Disabled - not commercial edition
+    assert not requests_enabled(
+        {
+            "api_version": "2.1.0",
+            "features": {"commercial": False, "requests": True},
+        }
+    )
+
+    # Disabled - API 2.0 (cannot verify commercial edition without features hash)
+    assert not requests_enabled({"api_version": "2.0.0", "features": {}})
+
+    # Disabled - old API version 1.x
+    assert not requests_enabled(
+        {
+            "api_version": "1.0.0",
+            "features": {"commercial": True, "requests": True},
+        }
+    )
+
+    # Disabled - None
+    assert not requests_enabled(None)
+
+    # Disabled - empty dict
+    assert not requests_enabled({})
+
+    # Disabled - malformed version
+    assert not requests_enabled(
+        {
+            "api_version": "invalid",
+            "features": {"commercial": True, "requests": True},
+        }
+    )

--- a/tests/test_request_commands.py
+++ b/tests/test_request_commands.py
@@ -17,9 +17,15 @@ runner = CliRunner()
 @pytest.fixture
 def mock_request_enabled():
     """Mock requests_enabled to return True."""
-    with patch(
-        "pwpush.commands.request.requests_enabled",
-        return_value=True,
+    with (
+        patch(
+            "pwpush.commands.request.requests_enabled",
+            return_value=True,
+        ),
+        patch(
+            "pwpush.commands.request.email_notifications_enabled",
+            return_value=True,
+        ),
     ):
         yield
 
@@ -44,7 +50,8 @@ def mock_request_make_request():
             "pwpush.commands.request.detect_api_capabilities",
             return_value={
                 "api_version": "2.1.0",
-                "features": {"commercial": True, "requests": True},
+                "edition": "commercial",
+                "features": {"requests": {"enabled": True}},
             },
         ),
     ):
@@ -142,7 +149,7 @@ def test_request_with_positional_text(mock_request_make_request, mock_request_en
         post_data["request"]["payload"]
         == "Please send me the production database password"
     )
-    assert post_data["request"]["email"] == "admin@example.com"
+    assert post_data["request"]["notify_emails_to"] == "admin@example.com"
 
 
 def test_request_with_content_file(
@@ -168,7 +175,7 @@ def test_request_with_content_file(
     assert post_call is not None
     post_data = _get_request_data_from_call(post_call)
     assert post_data["request"]["payload"] == "This is the request content from file"
-    assert post_data["request"]["email"] == "team@example.com"
+    assert post_data["request"]["notify_emails_to"] == "team@example.com"
 
 
 def test_request_with_both_text_and_content_error(
@@ -261,7 +268,7 @@ def test_request_with_content_file_and_attach_file(
     assert post_call is not None
     post_data = _get_request_data_from_call(post_call)
     assert post_data["request"]["payload"] == "Please fill out this form"
-    assert post_data["request"]["email"] == "hr@example.com"
+    assert post_data["request"]["notify_emails_to"] == "hr@example.com"
     args, kwargs = post_call
     assert kwargs.get("upload_files") is not None
 
@@ -482,41 +489,50 @@ def test_requests_enabled_helper():
     """Test the requests_enabled helper function."""
     from pwpush.api.capabilities import requests_enabled
 
-    # Enabled - API 2.1 with commercial and requests feature flag
+    # Enabled - API 2.1 with commercial edition and requests enabled
     assert requests_enabled(
         {
             "api_version": "2.1.0",
-            "features": {"commercial": True, "requests": True},
+            "edition": "commercial",
+            "features": {"requests": {"enabled": True}},
         }
     )
 
-    # Enabled - API 2.2+ with commercial and requests feature flag
+    # Enabled - API 2.2+ with commercial edition and requests enabled
     assert requests_enabled(
         {
             "api_version": "2.5.0",
-            "features": {"commercial": True, "requests": True},
+            "edition": "commercial",
+            "features": {"requests": {"enabled": True}},
         }
     )
 
-    # Disabled - requests feature flag false
+    # Disabled - requests disabled
     assert not requests_enabled(
         {
             "api_version": "2.1.0",
-            "features": {"commercial": True, "requests": False},
+            "edition": "commercial",
+            "features": {"requests": {"enabled": False}},
         }
     )
 
-    # Disabled - missing requests feature flag on 2.1+
+    # Disabled - missing requests feature on 2.1+
     assert not requests_enabled(
-        {"api_version": "2.1.0", "features": {"commercial": True}}
+        {"api_version": "2.1.0", "edition": "commercial", "features": {}}
     )
 
     # Disabled - not commercial edition
     assert not requests_enabled(
         {
             "api_version": "2.1.0",
-            "features": {"commercial": False, "requests": True},
+            "edition": "oss",
+            "features": {"requests": {"enabled": True}},
         }
+    )
+
+    # Disabled - missing edition field
+    assert not requests_enabled(
+        {"api_version": "2.1.0", "features": {"requests": {"enabled": True}}}
     )
 
     # Disabled - API 2.0 (cannot verify commercial edition without features hash)
@@ -526,7 +542,8 @@ def test_requests_enabled_helper():
     assert not requests_enabled(
         {
             "api_version": "1.0.0",
-            "features": {"commercial": True, "requests": True},
+            "edition": "commercial",
+            "features": {"requests": {"enabled": True}},
         }
     )
 
@@ -540,6 +557,16 @@ def test_requests_enabled_helper():
     assert not requests_enabled(
         {
             "api_version": "invalid",
-            "features": {"commercial": True, "requests": True},
+            "edition": "commercial",
+            "features": {"requests": {"enabled": True}},
+        }
+    )
+
+    # Enabled - boolean fallback format for backward compatibility
+    assert requests_enabled(
+        {
+            "api_version": "2.1.0",
+            "edition": "commercial",
+            "features": {"requests": True},
         }
     )

--- a/tests/test_request_commands.py
+++ b/tests/test_request_commands.py
@@ -146,7 +146,7 @@ def test_request_with_positional_text(mock_request_make_request, mock_request_en
     assert args[1] == "/api/v2/requests"
     post_data = _get_request_data_from_call(post_call)
     assert (
-        post_data["request"]["payload"]
+        post_data["request"]["request"]
         == "Please send me the production database password"
     )
     assert post_data["request"]["notify_emails_to"] == "admin@example.com"

--- a/tests/test_request_commands.py
+++ b/tests/test_request_commands.py
@@ -23,7 +23,7 @@ def mock_request_enabled():
             return_value=True,
         ),
         patch(
-            "pwpush.commands.request.email_notifications_enabled",
+            "pwpush.commands.request.request_email_notifications_enabled",
             return_value=True,
         ),
     ):


### PR DESCRIPTION
## Summary

This PR adds support for the Requests API, a Password Pusher Pro/Enterprise feature that allows users to create requests for others to send them secrets securely.

## Features

- **New `request` command**: Create requests with positional text or `--content` file input
- **File attachments**: Support `--attach-file` to attach files to requests
- **Full expiration controls**: `--days`, `--views`, `--deletable`, `--retrieval-step`
- **Email notifications**: `--notify` to receive notifications when request is fulfilled
- **JSON output**: `--json` and `--pretty` flags for scripting
- **API capability detection**: Automatic detection of `requests` and `commercial` features

## Usage Examples

```bash
# Create a basic request
pwpush request "Send me the production API key" --notify "devops@company.com"

# Request with content from file
pwpush request --content ./instructions.txt --notify "team@example.com"

# Request with file attachment
pwpush request "Send me the signed contract" --attach-file ./template.pdf --notify "vendor@example.com"
```

## Requirements

- Password Pusher Pro or Enterprise instance
- API version 2.1 or greater
- Authentication (API token required)

## Testing

- 17 new tests added for the request command
- 14 new tests for API capability detection
- All 337 tests pass

## Files Changed

- `pwpush/commands/request.py` (new)
- `tests/test_request_commands.py` (new)
- `pwpush/__main__.py`
- `pwpush/api/capabilities.py`
- `pwpush/api/endpoints.py`
- `tests/test_api_capabilities.py`
- `README.md`