### PR TITLE
Add --name support to push and push-file commands

### DIFF
--- a/pwpush/__main__.py
+++ b/pwpush/__main__.py
@@ -469,6 +469,10 @@ def push(
         "--notify-locale",
         help="Locale for notification emails (e.g., 'en', 'es', 'fr', 'de'). Only used when --notify is set.",
     ),
+    name: str | None = typer.Option(
+        None,
+        help="A name for the push shown in the dashboard, notifications and emails.",
+    ),
     json: bool = typer.Option(
         False, "--json", "-j", help="Output results in JSON format."
     ),
@@ -495,6 +499,7 @@ def push(
         kind=kind,
         notify=notify,
         notify_locale=notify_locale,
+        name=name,
         json=json,
         verbose=verbose,
         pretty=pretty,
@@ -527,6 +532,10 @@ def push_file(
         "--notify-locale",
         help="Locale for notification emails (e.g., 'en', 'es', 'fr', 'de'). Only used when --notify is set.",
     ),
+    name: str | None = typer.Option(
+        None,
+        help="A name for the file push shown in the dashboard, notifications and emails.",
+    ),
     payload: str = typer.Argument(""),
     json: bool = typer.Option(
         False, "--json", "-j", help="Output results in JSON format."
@@ -548,6 +557,7 @@ def push_file(
         note=note,
         notify=notify,
         notify_locale=notify_locale,
+        name=name,
         payload=payload,
         json=json,
         verbose=verbose,

--- a/pwpush/api/endpoints.py
+++ b/pwpush/api/endpoints.py
@@ -79,6 +79,8 @@ def adapt_text_payload_for_profile(
         push_payload["expire_after_views"] = source["expire_after_views"]
     if "note" in source:
         push_payload["note"] = source["note"]
+    if "name" in source:
+        push_payload["name"] = source["name"]
     if "deletable_by_viewer" in source:
         push_payload["deletable_by_viewer"] = source["deletable_by_viewer"]
     if "retrieval_step" in source:
@@ -117,6 +119,8 @@ def adapt_file_payload_for_profile(
         push_payload["expire_after_views"] = source["expire_after_views"]
     if "note" in source:
         push_payload["note"] = source["note"]
+    if "name" in source:
+        push_payload["name"] = source["name"]
     if "deletable_by_viewer" in source:
         push_payload["deletable_by_viewer"] = source["deletable_by_viewer"]
     if "retrieval_step" in source:

--- a/pwpush/commands/push.py
+++ b/pwpush/commands/push.py
@@ -165,6 +165,10 @@ def push_cmd(
         "--notify-locale",
         help="Locale for notification emails (e.g., 'en', 'es', 'fr', 'de'). Only used when --notify is set.",
     ),
+    name: str | None = typer.Option(
+        None,
+        help="A name for the push shown in the dashboard, notifications and emails.",
+    ),
     json: bool = typer.Option(
         False, "--json", "-j", help="Output results in JSON format."
     ),
@@ -287,6 +291,9 @@ def push_cmd(
 
     if note:
         data["password"]["note"] = note
+
+    if name:
+        data["password"]["name"] = name
 
     if views:
         data["password"]["expire_after_views"] = views
@@ -419,6 +426,10 @@ def push_file_cmd(
         "--notify-locale",
         help="Locale for notification emails (e.g., 'en', 'es', 'fr', 'de'). Only used when --notify is set.",
     ),
+    name: str | None = typer.Option(
+        None,
+        help="A name for the file push shown in the dashboard, notifications and emails.",
+    ),
     payload: str = typer.Argument(
         "",
     ),
@@ -483,6 +494,9 @@ def push_file_cmd(
 
     if note:
         data["file_push"]["note"] = note
+
+    if name:
+        data["file_push"]["name"] = name
 
     # Email notification options require authentication
     if notify or notify_locale:

--- a/tests/test_api_v2.py
+++ b/tests/test_api_v2.py
@@ -370,6 +370,7 @@ class TestAdaptTextPayloadForProfile:
                 "expire_after_views": 5,
                 "expire_after_days": 7,
                 "note": "test note",
+                "name": "Test Push Name",
                 "deletable_by_viewer": True,
                 "retrieval_step": False,
                 "passphrase": "secret-pass",
@@ -384,6 +385,7 @@ class TestAdaptTextPayloadForProfile:
         assert push["expire_after_views"] == 5
         assert push["expire_after_duration"] == 12  # 7 days maps to duration 12
         assert push["note"] == "test note"
+        assert push["name"] == "Test Push Name"
         assert push["deletable_by_viewer"] is True
         assert push["retrieval_step"] is False
         assert push["passphrase"] == "secret-pass"
@@ -415,12 +417,16 @@ class TestAdaptFilePayloadForProfile:
                 "kind": "file",
                 "expire_after_views": 3,
                 "expire_after_days": 1,
+                "note": "file note",
+                "name": "Test File Name",
             }
         }
         result = adapt_file_payload_for_profile(payload, API_PROFILE_V2)
         assert result["push"]["kind"] == "file"
         assert result["push"]["expire_after_views"] == 3
         assert result["push"]["expire_after_duration"] == 6  # 1 day maps to 6
+        assert result["push"]["note"] == "file note"
+        assert result["push"]["name"] == "Test File Name"
 
 
 class TestAdaptFileUploadsForProfile:

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -440,3 +440,29 @@ def test_email_notifications_enabled_helper():
 
     # Disabled - empty dict
     assert not email_notifications_enabled({})
+
+
+def test_push_with_name(mock_make_request):
+    """Test push with --name option includes name in payload."""
+    result = runner.invoke(
+        app, ["push", "--secret", "test-secret", "--name", "Production Password"]
+    )
+    assert result.exit_code == 0
+    post_call = _get_post_call(mock_make_request)
+    assert post_call is not None
+    assert post_call[1]["post_data"]["password"]["name"] == "Production Password"
+
+
+def test_push_file_with_name(mock_make_request, monkeypatch):
+    """Test push-file with --name option includes name in payload."""
+    monkeypatch.setitem(user_config["instance"], "email", "user@example.test")
+    monkeypatch.setitem(user_config["instance"], "token", "token-value")
+
+    result = runner.invoke(
+        app, ["push-file", "./README.md", "--name", "Q4 Financial Report"]
+    )
+    assert result.exit_code == 0
+    post_call = _get_post_call(mock_make_request)
+    assert post_call is not None
+    # For file pushes, the data structure uses "file_push" key
+    assert post_call[1]["post_data"]["file_push"]["name"] == "Q4 Financial Report"


### PR DESCRIPTION
## Summary

This PR adds `--name` support to the `push` and `push-file` commands, similar to how it was already implemented for the `request` command.

## Changes

- Added `--name` option to `push` command in `__main__.py`
- Added `--name` option to `push-file` command in `__main__.py`
- Added `name` parameter to `push_cmd()` in `commands/push.py`
- Added `name` parameter to `push_file_cmd()` in `commands/push.py`
- Updated `adapt_text_payload_for_profile()` in `api/endpoints.py` to include `name` field in v2 API payload
- Updated `adapt_file_payload_for_profile()` in `api/endpoints.py` to include `name` field in v2 API payload

## Usage

```bash
# Name a password push
pwpush push --secret "mysecret" --name "Production Database Password"

# Name a file push
pwpush push-file document.pdf --name "Q4 Financial Report"
```

The name will be shown in the dashboard, notifications, and emails.